### PR TITLE
KBV-128 Add kbv-session DynamoDB table

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1,0 +1,48 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: "AWS::Serverless-2016-10-31"
+Description: >
+  di-ipv-cri-kbv-api
+  SAM Template for the kbv api
+
+Resources:
+  KBVSessionTable:
+    Type: "AWS::DynamoDB::Table"
+    Properties:
+      TableName: "kbv-session"
+      BillingMode: "PAY_PER_REQUEST"
+      AttributeDefinitions:
+        -
+          AttributeName: "session-id"
+          AttributeType: "S"
+        -
+          AttributeName: "authorization-code"
+          AttributeType: "S"
+        -
+          AttributeName: "token"
+          AttributeType: "S"
+
+      KeySchema:
+        -
+          AttributeName: "session-id"
+          KeyType: "HASH"
+      GlobalSecondaryIndexes:
+        -
+          IndexName: "authorization-code-index"
+          KeySchema:
+            -
+              AttributeName: "authorization-code"
+              KeyType: "HASH"
+          Projection:
+            NonKeyAttributes:
+              - "session-id"
+            ProjectionType: "INCLUDE"
+        -
+          IndexName: "token-index"
+          KeySchema:
+            -
+              AttributeName: "token"
+              KeyType: "HASH"
+          Projection:
+            NonKeyAttributes:
+              - "session-id"
+            ProjectionType: "INCLUDE"

--- a/template.yaml
+++ b/template.yaml
@@ -46,3 +46,6 @@ Resources:
             NonKeyAttributes:
               - "session-id"
             ProjectionType: "INCLUDE"
+      TimeToLiveSpecification:
+         AttributeName: expiry-date
+         Enabled: true


### PR DESCRIPTION
Add a new DynamoDB table to support the KBV credential issuer API.

See discussion of the table at https://govukverify.atlassian.net/browse/KBV-128.

There are no attribute definition for attributes that are not required for indexes i.e. the `questions` or `auth_ref_no`.

This has been SAM deployed to our DI IPV dev environment.