### PR TITLE
KBV-179: openapi definition for the API gateway

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -1,0 +1,57 @@
+openapi: "3.0.1"
+info:
+  title: "Knowledge Base Verification Credential Issuer Api"
+  version: "1.0"
+
+paths:
+  /session:
+    post:
+      responses:
+        "201":
+          description: "201 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Session"
+        "400":
+          description: "400 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: "500 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+      security:
+        - sigv4: [ ]
+      x-amazon-apigateway-integration:
+        credentials: "arn:aws:iam::*:user/*"
+        type: "aws_proxy"
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${KBVSessionFunction.Arn}/invocations"
+        passthroughBehavior: "when_no_match"
+components:
+  securitySchemes:
+    sigv4:
+      type: "apiKey"
+      name: "Authorization"
+      in: "header"
+      x-amazon-apigateway-authtype: "awsSigv4"
+  schemas:
+    Session:
+      required:
+        - "session_id"
+      type: "object"
+      properties:
+        session_id:
+          type: "string"
+    Error:
+      title: "Error Schema"
+      type: "object"
+      properties:
+        message:
+          type: "string"

--- a/template.yaml
+++ b/template.yaml
@@ -34,7 +34,7 @@ Resources:
       DefinitionBody:
         openapi: "3.0.1" # workaround to get `sam validate` to work
         paths: # workaround to get `sam validate` to work
-          /foo:
+          /never-created:
             options: { } # workaround to get `sam validate` to work
         Fn::Transform:
           Name: AWS::Include

--- a/template.yaml
+++ b/template.yaml
@@ -11,17 +11,50 @@ Globals:
   Function:
     Timeout: 60
 
+
+Parameters:
+  Environment:
+    Description: environment name
+    Default: dev
+    Type: String
+    AllowedValues:
+      - dev
+      - staging
+      - integration
+      - prod
+    ConstraintDescription: specify dev, staging, integration or prod for environment
+
+
 Resources:
 
   KBVSessionApi:
     Type: AWS::Serverless::Api
     Properties:
-      StageName: Dev
-      Auth:
-        InvokeRole: CALLER_CREDENTIALS
+      StageName: !Ref Environment
+      DefinitionBody:
+        openapi: "3.0.1" # workaround to get `sam validate` to work
+        paths: # workaround to get `sam validate` to work
+          /foo:
+            options: { } # workaround to get `sam validate` to work
+        Fn::Transform:
+          Name: AWS::Include
+          Parameters:
+            Location: './api.yaml'
+      OpenApiVersion: 3.0.1
+      EndpointConfiguration:
+        Type: REGIONAL
+
+
+  FunctionPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref KBVSessionFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${KBVSessionApi}*"
 
   KBVSessionTable:
-    Type: "AWS::DynamoDB::Table"
+    Type: AWS::DynamoDB::Table
     Properties:
       TableName: !Sub "kbv-session-${AWS::StackName}"
       BillingMode: "PAY_PER_REQUEST"
@@ -97,15 +130,6 @@ Resources:
           EXPERIAN_API_WRAPPER_SAA_RESOURCE: http://localhost:8080/question-request
           EXPERIAN_API_WRAPPER_RTQ_RESOURCE: http://localhost:8080/question-answer
           EXPERIAN_API_WRAPPER_URL: http://localhost:8080/
-      Events:
-        KBVSessionApi:
-          Type: Api
-          Properties:
-            Path: /session
-            Method: Post
-            RestApiId: !Ref KBVSessionApi
-            Auth:
-              Authorizer: AWS_IAM
 
 Outputs:
   # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function
@@ -113,11 +137,11 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   KBVSessionApi:
     Description: "API Gateway endpoint URL for Dev KBVSession function"
-    Value: !Sub "https://${KBVSessionApi}.execute-api.${AWS::Region}.amazonaws.com/Dev/session/"
+    Value: !Sub "https://${KBVSessionApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/session/"
   KBVSessionFunction:
     Description: "KBVSession check lambda function ARN"
     Value: !GetAtt KBVSessionFunction.Arn
   KBVSessionFunctionIamRole:
     Description: "Implicit IAM Role created for KBVSession function"
     Value: !GetAtt KBVSessionFunction.Arn
-  
+


### PR DESCRIPTION
### What changed

This PR is to incorporate the use of an Open Api definition for Api gateway endpoints.
It turns out that an s3 bucket is not actually required to link the Open Api definition to
the SAM template.

### Why did it change

Open Api is more descriptive and can do stuff like validation, also provides a better description and documentaion of the use of the Api.


- [KBV-179](https://govukverify.atlassian.net/browse/KBV-179)

