### PR TITLE
[KBV-177] GitHub actions sam deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,8 @@
 name: Build
 on:
-  push:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,6 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && ${{ github.ref }} == 'main'
     timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,62 @@
+name: Deploy
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && ${{ github.ref }} == 'main'
+    timeout-minutes: 15
+    env:
+      AWS_REGION: eu-west-2
+      ENVIRONMENT: dev
+      STACK_NAME: di-ipv-cri-kbv-api-dev
+      ROLLBACK_ACTION: "--disable-rollback"
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Setup SAM
+        uses: aws-actions/setup-sam@v1
+
+      - name: Assume temporary AWS role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Get signing profile name
+        id: code_signing
+        run: echo "::set-output name=profile::$(aws ssm get-parameter --region ${{ env.AWS_REGION }} --name '${{ secrets.AWS_PROFILE_PATH }}' | jq '.Parameter.Value')"
+
+      - name: Gradle build
+        run: ./gradlew clean build buildZip
+
+      - name: SAM build
+        run: sam build -t template.yaml --config-env ${{ env.ENVIRONMENT }}
+
+      - name: SAM Validate
+        run: sam validate --region ${{ env.AWS_REGION }} -t template.yaml --config-env ${{ env.ENVIRONMENT }}
+
+      # - name: Upload API config
+      #   run: aws s3 cp api.yaml s3://${{ secrets.AWS_CONFIG_BUCKET }}/${{ env.ENVIRONMENT }}/api.yaml
+
+      - name: SAM deploy
+        run: |
+          sam deploy -t template.yaml --config-env ${{ env.ENVIRONMENT }} \
+            --config-file samconfig.toml --no-fail-on-empty-changeset \
+            --signing-profiles KBVSessionFunction=${{ steps.code_signing.outputs.profile }} \
+            --stack-name ${{ env.STACK_NAME }} --s3-bucket di-ipv-cri-lambda-artifact-bucket \
+            --s3-prefix --stack-name ${{ env.STACK_NAME }} --region ${{ env.AWS_REGION }} \
+            --no-confirm-changeset ${{ env.ROLLBACK_ACTION }} --capabilities CAPABILITY_IAM

--- a/README.md
+++ b/README.md
@@ -18,4 +18,16 @@ cf push
 
 ## Deploy to AWS lambda
 
-to do
+Automated GitHub actions deployments to di-ipv-cri-dev have been enabled for this repository.
+
+The automated deployments are triggered on a push to main after PR approval.
+
+GitHub secrets are required which must be configured in an environment for security reasons.
+
+Required GitHub secrets:
+
+| Secret | Description |
+| ------ | ----------- |
+| AWS_ROLE_ARN | Assumed role IAM ARN |
+| AWS_PROFILE_PATH | Parameter Store path to the signing profile versioned ARN |
+| AWS_ROLE_SESSION | Assumed Role Session ID

--- a/template.yaml
+++ b/template.yaml
@@ -131,6 +131,16 @@ Resources:
           EXPERIAN_API_WRAPPER_RTQ_RESOURCE: http://localhost:8080/question-answer
           EXPERIAN_API_WRAPPER_URL: http://localhost:8080/
 
+  KBVSessionFunctionCodeSigning:
+    Type: AWS::Lambda::CodeSigningConfig
+    Properties:
+      Description: "Code Signing for KBVSessionFunction"
+      AllowedPublishers:
+        SigningProfileVersionArns:
+          - "{{resolve:ssm:/dev/credentialIssuers/kbv/sam/signingProfileVersionArn}}"
+      CodeSigningPolicies:
+        UntrustedArtifactOnDeployment: "Enforce"
+
 Outputs:
   # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function
   # Find out more about other implicit resources you can reference within SAM


### PR DESCRIPTION
## Proposed changes

Update to enable GitHub actions deployments into the di-ipv-cri-dev AWS account.

### What changed

* Added GitHub actions workflow for deployment on push to main after PR approval.
* Updated SAM template to include code signing.

### Why did it change

To enable automated GitHub actions deployments into the di-ipv-cri-dev AWS account.

### Issue tracking

- [KBV-177](https://govukverify.atlassian.net/browse/KBV-177)

## Checklists

### Environment variables or secrets

Required GitHub secrets inside and environment for added security:

| Secret | Description |
| ------ | ----------- |
| AWS_ROLE_ARN | Assumed role IAM ARN |
| AWS_PROFILE_PATH | Parameter Store path to the signing profile versioned ARN |
| AWS_ROLE_SESSION | Assumed Role Session ID

- [X] Documented in the [README](./blob/main/README.md)
- [X] Added to deployment repository
