### PR TITLE
BAU: Remove extra blank array entry

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -34,7 +34,7 @@ Conditions:
       - Fn::Equals:
           - !Ref PermissionsBoundary
           - "none"
-          -
+
 Globals:
   Function:
     PermissionsBoundary: !If


### PR DESCRIPTION
Remove extra array entry in Permission Boundary
This cause stack deployment to fail on main

see: https://github.com/alphagov/di-ipv-cri-kbv-api/runs/6350736391?check_suite_focus=true
