### PR TITLE
BAU: Set Java tiered compilation level

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -51,6 +51,7 @@ Globals:
     Tracing: Active
     Environment:
       Variables:
+        JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
         AWS_STACK_NAME: !Sub ${AWS::StackName}
         POWERTOOLS_LOG_LEVEL: INFO
 


### PR DESCRIPTION
Mark Sailes released a blog post describing how you can reduce cold
start times by setting the Java tiered compilation level. Setting this
global will make the change to all our kbv-api lambdas.
