### PR TITLE
KBV-400 Use code signing config arn if supplied, irrespective of environment

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -24,9 +24,11 @@ Parameters:
     Default: "none"
 
 Conditions:
-  CreateDevResources: !Equals
-    - !Ref Environment
-    - dev
+  UseCodeSigningConfigArn:
+    Fn::Not:
+      - Fn::Equals:
+          - !Ref CodeSigningConfigArn
+          - "none"
   IsStubEnvironment: !Or
     - !Equals [ !Ref Environment, dev]
     - !Equals [ !Ref Environment, build ]
@@ -44,9 +46,9 @@ Globals:
       - !Ref PermissionsBoundary
       - !Ref AWS::NoValue
     CodeSigningConfigArn: !If
-      - CreateDevResources
-      - !Ref AWS::NoValue
+      - UseCodeSigningConfigArn
       - !Ref CodeSigningConfigArn
+      - !Ref AWS::NoValue
     Timeout: 30 # seconds
     Runtime: java11
     AutoPublishAlias: live


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

If the sam template gets a `CodeSigningConfigArn` as a parameter then use it.

Currently we never used a `CodeSigningConfigArn` in the dev environment, and this breaks the updated dev platform team secure pipeline that now requires a signer.

This change works for a dev that slings up a sam deploy - this PR will prove that the kbv dev pipeline can deploy the api stack. 


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-400](https://govukverify.atlassian.net/browse/KBV-400)
