### PR TITLE
Configure question and answer endpoint in KBV CRI

### DIFF
--- a/infrastructure/lambda/api.yaml
+++ b/infrastructure/lambda/api.yaml
@@ -77,6 +77,39 @@ paths:
           Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${KBVQuestionFunction.Arn}/invocations"
         passthroughBehavior: "when_no_match"
 
+  /answer:
+    post:
+      parameters:
+        - $ref: "#/components/parameters/SessionHeader"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Answer"
+        required: true
+      responses:
+        "200":
+          description: "200 response"
+        "400":
+          description: "400 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: "500 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+      x-amazon-apigateway-request-validator: "Validate both"
+      x-amazon-apigateway-integration:
+        type: "aws_proxy"
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${KBVAnswerFunction.Arn}/invocations"
+        passthroughBehavior: "when_no_match"
+
 components:
   parameters:
     SessionHeader:
@@ -176,6 +209,17 @@ components:
           type: array
           items:
             type: "string"
+    Answer:
+      type: "object"
+      properties:
+        questionId:
+          description: The unique identifier for the question
+          maxLength: 6
+          type: "string"
+        answer:
+          description: Answer provided by the user
+          maxLength: 50
+          type: "string"
     Address:
       title: "Address Update Request"
       type: "array"

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -290,6 +290,44 @@ Resources:
               Resource:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/clients/*"
 
+  KBVAnswerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../../lambdas/answer/build/distributions/answer.zip
+      Handler: uk.gov.di.ipv.cri.kbv.api.handler.QuestionAnswerHandler::handleRequest
+      Environment:
+        Variables:
+          POWERTOOLS_METRICS_NAMESPACE: di-ipv-cri-kbv-api
+          POWERTOOLS_SERVICE_NAME: di-ipv-cri-kbv-api
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - AWSXrayWriteOnlyAccess
+        - DynamoDBReadPolicy:
+            TableName: !Ref KBVTable
+        - DynamoDBWritePolicy:
+            TableName: !Ref KBVTable
+        - Statement:
+            - Effect: Allow
+              Action:
+                - ssm:GetParameter
+              Resource:
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/KBVTableName"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/SessionTableName"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/SessionTtl"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/PersonIdentityTableName"
+        - Statement:
+            - Sid: ReadSecretsPolicy
+              Effect: Allow
+              Action:
+                - 'secretsmanager:GetSecretValue'
+              Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${Environment}/di-ipv-cri-experian-kbv-api/experian*'
+        - Statement:
+            - Effect: Allow
+              Action:
+                - ssm:GetParametersByPath
+              Resource:
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/clients/*"
+
   KBVTable:
     Type: "AWS::DynamoDB::Table"
     Properties:
@@ -553,6 +591,13 @@ Resources:
     Properties:
       Action: lambda:InvokeFunction
       FunctionName: !GetAtt KBVQuestionFunction.Arn
+      Principal: apigateway.amazonaws.com
+
+  KBVAnswerFunctionPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !GetAtt KBVAnswerFunction.Arn
       Principal: apigateway.amazonaws.com
 
 Outputs:

--- a/lambdas/answer/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandlerTest.java
+++ b/lambdas/answer/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandlerTest.java
@@ -31,7 +31,6 @@ import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -213,18 +212,16 @@ class QuestionAnswerHandlerTest {
         when(mockKBVStorageService.getSessionId(
                         sessionHeader.get(QuestionAnswerHandler.HEADER_SESSION_ID)))
                 .thenReturn(Optional.ofNullable(kbvSessionItemMock));
-        //        when(mockObjectMapper.readValue(kbvSessionItemMock.getQuestionState(),
-        // QuestionState.class))
-        //                .thenThrow(JsonProcessingException.class);
+        when(mockObjectMapper.readValue(kbvSessionItemMock.getQuestionState(), QuestionState.class))
+                .thenThrow(JsonProcessingException.class);
         setupEventProbeErrorBehaviour();
         APIGatewayProxyResponseEvent response =
                 questionAnswerHandler.handleRequest(input, contextMock);
 
-        //        assertEquals(
-        //                "{ \"error\":\"Failed to parse object using ObjectMapper.\" }",
-        // response.getBody());
-        //        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatusCode());
-        //        verify(mockEventProbe).counterMetric("post_answer", 0d);
+        assertEquals(
+                "{ \"error\":\"Failed to parse object using ObjectMapper.\" }", response.getBody());
+        assertEquals(HttpStatusCode.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        verify(mockEventProbe).counterMetric("post_answer", 0d);
     }
 
     @Test
@@ -260,12 +257,12 @@ class QuestionAnswerHandlerTest {
                         factory,
                         mockEventProbe);
 
-        Exception unExpectedException = new Exception();
-        assertThrows(
-                unExpectedException.getClass(),
-                () -> questionAnswerHandler.handleRequest(input, contextMock));
-        assertEquals(HttpStatusCode.INTERNAL_SERVER_ERROR, 500);
+        setupEventProbeErrorBehaviour();
+        APIGatewayProxyResponseEvent response =
+                questionAnswerHandler.handleRequest(input, mock(Context.class));
 
+        assertEquals(HttpStatusCode.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        verify(mockEventProbe).counterMetric("post_answer", 0d);
         verify(mockEventProbe).log(any(Level.class), any(Exception.class));
     }
 

--- a/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
+++ b/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
@@ -300,21 +300,21 @@ class QuestionHandlerTest {
         Map<String, String> sessionHeader = Map.of(HEADER_SESSION_ID, UUID.randomUUID().toString());
 
         Context contextMock = mock(Context.class);
-        KBVItem SessionItemMock = mock(KBVItem.class);
+        KBVItem kbvItemMock = mock(KBVItem.class);
         PersonIdentity personIdentityMock = mock(PersonIdentity.class);
         QuestionState questionStateMock = mock(QuestionState.class);
 
         when(input.getHeaders()).thenReturn(sessionHeader);
         when(mockKBVStorageService.getKBVItem(sessionHeader.get(HEADER_SESSION_ID)))
-                .thenReturn(SessionItemMock);
+                .thenReturn(kbvItemMock);
         when(mockPersonIdentityService.getPersonIdentity(
                         UUID.fromString(sessionHeader.get(HEADER_SESSION_ID))))
                 .thenReturn(personIdentityMock);
 
-        when(mockObjectMapper.readValue(SessionItemMock.getQuestionState(), QuestionState.class))
+        when(mockObjectMapper.readValue(kbvItemMock.getQuestionState(), QuestionState.class))
                 .thenReturn(questionStateMock);
 
-        when(SessionItemMock.getAuthorizationCode()).thenReturn("authorisation-code");
+        when(kbvItemMock.getAuthorizationCode()).thenReturn("authorisation-code");
         APIGatewayProxyResponseEvent response = questionHandler.handleRequest(input, contextMock);
 
         assertEquals(HttpStatusCode.NO_CONTENT, response.getStatusCode());

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/KBVItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/KBVItem.java
@@ -12,7 +12,6 @@ public class KBVItem {
     private String expiryDate;
     private String authRefNo;
     private String urn;
-    private String userAttributes;
     private String status;
 
     public void setAuthorizationCode(String authorizationCode) {
@@ -65,14 +64,6 @@ public class KBVItem {
 
     public void setUrn(String urn) {
         this.urn = urn;
-    }
-
-    public String getUserAttributes() {
-        return userAttributes;
-    }
-
-    public void setUserAttributes(String userAttributes) {
-        this.userAttributes = userAttributes;
     }
 
     @DynamoDbPartitionKey

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/KBVStorageService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/KBVStorageService.java
@@ -12,8 +12,7 @@ public class KBVStorageService {
     private final DataStore<KBVItem> dataStore;
 
     public KBVStorageService() {
-        this.dataStore =
-                new DataStore<KBVItem>(getKBVTableName(), KBVItem.class, DataStore.getClient());
+        this.dataStore = new DataStore<>(getKBVTableName(), KBVItem.class, DataStore.getClient());
     }
 
     public KBVStorageService(DataStore<KBVItem> datastore) {


### PR DESCRIPTION
KBV CRI needs to have the `/question` and `/answer` endpoints to interact with the Experian SOAP endpoints for a KBV CRI journey

## Proposed changes
- Changes made to the `template.yaml` file to include the `answer` endpoint
- Changes made to the `api.yaml` file to schema objects
- General code changes in the handler/service areas and fixing broken unit tests

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-406](https://govukverify.atlassian.net/browse/KBV-406)
- [KBV-405](https://govukverify.atlassian.net/browse/KBV-405)

## Checklists
- Reusing the common Session endpoint and the `Session` table
- Reusing the common `PersonIdentity` table

### Environment variables or secrets
Added the Experian `keystore` and `keystore-password` via `template.yaml` in AWS - Secrets manager with following keys:
- /dev/di-ipv-cri-experian-kbv-api/experian/keystore-password
- /dev/di-ipv-cri-experian-kbv-api/experian/keystore