### PR TITLE
Configure question endpoint in KBV CRI

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -32,8 +32,12 @@ Conditions:
   IsStubEnvironment: !Or
     - !Equals [ !Ref Environment, dev]
     - !Equals [ !Ref Environment, build ]
-  IsProdLikeEnvironment:
-    !Not [Condition: IsStubEnvironment]
+    - !Equals [ !Ref Environment, staging ]
+    - !Equals [ !Ref Environment, integration ]
+  IsProdLikeEnvironment: !Or
+    - !Equals [ !Ref Environment, staging ]
+    - !Equals [ !Ref Environment, integration ]
+    - !Equals [ !Ref Environment, production ]
   UsePermissionsBoundary:
     Fn::Not:
       - Fn::Equals:
@@ -85,6 +89,8 @@ Mappings:
     Environment:
       dev: "ES256"
       build: "ES256"
+      staging: "ES256"
+      integration: "ES256"
 
   IPVCore1AuthenticationAlgMapping:
     Environment:
@@ -96,6 +102,8 @@ Mappings:
     Environment:
       dev: "https://dev-di-ipv-cri-kbv-front.london.cloudapps.digital"
       build: "https://build-di-ipv-cri-kbv-front.london.cloudapps.digital"
+      staging: "https://staging-di-ipv-cri-kbv-front.london.cloudapps.digital"
+      integration: "https://integration-di-ipv-cri-kbv-front.london.cloudapps.digital"
 
   IPVCore1AudienceMapping:
     Environment:
@@ -107,34 +115,40 @@ Mappings:
     Environment:
       dev: "https://di-ipv-core-stub.london.cloudapps.digital"
       build: "https://di-ipv-core-stub.london.cloudapps.digital"
+      staging: "https://di-ipv-core-stub.london.cloudapps.digital"
+      integration: "https://di-ipv-core-stub.london.cloudapps.digital"
 
   IPVCore1IssuerMapping:
     Environment:
-      staging: "https://staging-di-ipv-core-front.london.cloudapps.digital"
-      integration: "https://integration-di-ipv-core-front.london.cloudapps.digital"
-      production: "https://di-ipv-core-front.london.cloudapps.digital"
+      staging: "https://identity.staging.account.gov.uk"
+      integration: "https://identity.integration.account.gov.uk"
+      production: "https://identity.account.gov.uk"
 
   IPVCoreStubPublicSigningJwkBase64Mapping:
     Environment:
       dev: "ewogICAgImt0eSI6ICJFQyIsCiAgICAidXNlIjogInNpZyIsCiAgICAiY3J2IjogIlAtMjU2IiwKICAgICJraWQiOiAiaXB2LWNvcmUtc3R1Yi0xLWZyb20tbWtqd2sub3JnIiwKICAgICJ4IjogIklmUjFQejlPdWNJMll3YldKVGEtT3h0MDJ6X3pnTkR5RmtocGZ3OFFXcjAiLAogICAgInkiOiAiWGo2alJ6S0EwUWVTTEMtZTE1bVg3U2hucG9xZ0c4d1F3ZWcwNlhJYTBEcyIsCiAgICAiYWxnIjogIkVTMjU2Igp9"
       build: "ewogICAgImt0eSI6ICJFQyIsCiAgICAidXNlIjogInNpZyIsCiAgICAiY3J2IjogIlAtMjU2IiwKICAgICJraWQiOiAiaXB2LWNvcmUtc3R1Yi0xLWZyb20tbWtqd2sub3JnIiwKICAgICJ4IjogIklmUjFQejlPdWNJMll3YldKVGEtT3h0MDJ6X3pnTkR5RmtocGZ3OFFXcjAiLAogICAgInkiOiAiWGo2alJ6S0EwUWVTTEMtZTE1bVg3U2hucG9xZ0c4d1F3ZWcwNlhJYTBEcyIsCiAgICAiYWxnIjogIkVTMjU2Igp9"
+      staging: "ewogICAgImt0eSI6ICJFQyIsCiAgICAidXNlIjogInNpZyIsCiAgICAiY3J2IjogIlAtMjU2IiwKICAgICJraWQiOiAiaXB2LWNvcmUtc3R1Yi0xLWZyb20tbWtqd2sub3JnIiwKICAgICJ4IjogIklmUjFQejlPdWNJMll3YldKVGEtT3h0MDJ6X3pnTkR5RmtocGZ3OFFXcjAiLAogICAgInkiOiAiWGo2alJ6S0EwUWVTTEMtZTE1bVg3U2hucG9xZ0c4d1F3ZWcwNlhJYTBEcyIsCiAgICAiYWxnIjogIkVTMjU2Igp9"
+      integration: "ewogICAgImt0eSI6ICJFQyIsCiAgICAidXNlIjogInNpZyIsCiAgICAiY3J2IjogIlAtMjU2IiwKICAgICJraWQiOiAiaXB2LWNvcmUtc3R1Yi0xLWZyb20tbWtqd2sub3JnIiwKICAgICJ4IjogIklmUjFQejlPdWNJMll3YldKVGEtT3h0MDJ6X3pnTkR5RmtocGZ3OFFXcjAiLAogICAgInkiOiAiWGo2alJ6S0EwUWVTTEMtZTE1bVg3U2hucG9xZ0c4d1F3ZWcwNlhJYTBEcyIsCiAgICAiYWxnIjogIkVTMjU2Igp9"
 
   IPVCore1PublicSigningJwkBase64Mapping:
     Environment:
       staging: "eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6ImtlMVRNRnFNb0Z5eHg1eXpOdFFRbGw0dk9yeHZUdFBKQ0huUzRqOHpoMlUiLCJ5IjoicURLX0g4QXpKS2FIbU1zaHg5TGp2LTB0ek5rV2EtSkVHUzJtZHRKUjFPQSJ9"
-      integration: "todo"
+      integration: "eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6IkJUUWdWQjU0RE9JcDU0eGRVSVg0SGtUX3pCdjZHdVdMV1RUTkdxMk15dEkiLCJ5IjoiTFFRamx5ZEtOMUhXZFJQcFBpalJObEJrbi1qaDgzZzBBUmIyNms2WVh1byJ9"
       production: "todo"
 
   IPVCoreStubRedirectURIMapping:
     Environment:
       dev: "https://di-ipv-core-stub.london.cloudapps.digital/callback"
       build: "https://di-ipv-core-stub.london.cloudapps.digital/callback"
+      staging: "https://di-ipv-core-stub.london.cloudapps.digital/callback"
+      integration: "https://di-ipv-core-stub.london.cloudapps.digital/callback"
 
   IPVCore1RedirectURIMapping:
     Environment:
-      staging: "https://staging-di-ipv-core-front.london.cloudapps.digital/credential-issuer/callback?id=debugKBV"
-      integration: "https://integration-di-ipv-core-front.london.cloudapps.digital/credential-issuer/callback?id=kbv"
-      production: "https://di-ipv-core-front.london.cloudapps.digital/credential-issuer/callback?id=kbv"
+      staging: "https://identity.staging.account.gov.uk/credential-issuer/callback?id=kbv"
+      integration: "https://identity.integration.account.gov.uk/credential-issuer/callback?id=kbv"
+      production: "https://identity.account.gov.uk/credential-issuer/callback?id=kbv"
 
   VerifiableCredentialIssuerMapping:
     Environment:
@@ -194,7 +208,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: ../../common-lambdas/session/build/distributions/session.zip
-      Handler: uk.gov.di.ipv.cri.address.api.handler.SessionHandler::handleRequest
+      Handler: uk.gov.di.ipv.cri.common.api.handler.SessionHandler::handleRequest
       Environment:
         Variables:
           POWERTOOLS_METRICS_NAMESPACE: di-ipv-cri-kbv-api
@@ -210,7 +224,7 @@ Resources:
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
         - KMSDecryptPolicy:
-            KeyId: !Ref KBVCriDecryptionKey
+            KeyId: !ImportValue core-infrastructure-CriDecryptionKey1Id
         - Statement:
             - Effect: Allow
               Action:
@@ -218,7 +232,7 @@ Resources:
               Resource:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/SessionTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/SessionTtl"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/AddressCriAudience"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/KBVCriAudience"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/AuthRequestKmsEncryptionKeyId"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/PersonIdentityTableName"
         - Statement:
@@ -276,64 +290,6 @@ Resources:
               Resource:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/clients/*"
 
-  KBVCriVcSigningKey:
-    Type: AWS::KMS::Key
-    Properties:
-      Description: Asymmetric key used by KBV Cri for signing verifiable credentials.
-      Enabled: true
-      KeySpec: ECC_NIST_P256
-      KeyUsage: SIGN_VERIFY
-      KeyPolicy:
-        Version: '2012-10-17'
-        Statement:
-          - Sid: 'Enable Root access'
-            Effect: Allow
-            Principal:
-              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
-            Action:
-              - 'kms:*'
-            Resource: '*'
-      Tags:
-        - Key: "jwkset"
-          Value: "true"
-        - Key: "awsStackName"
-          Value: !Sub "${AWS::StackName}"
-
-  SigningKeyAlias:
-    Type: AWS::KMS::Alias
-    Properties:
-      AliasName: !Sub alias/${AWS::StackName}/${Environment}/KBVCriVcSigningKey
-      TargetKeyId: !Ref KBVCriVcSigningKey
-
-  KBVCriDecryptionKey:
-    Type: AWS::KMS::Key
-    Properties:
-      Description: Asymmetric key used by KBV CRI to decrypt the Authorization JAR JWE
-      Enabled: true
-      KeySpec: RSA_2048
-      KeyUsage: ENCRYPT_DECRYPT
-      KeyPolicy:
-        Version: '2012-10-17'
-        Statement:
-          - Sid: 'Enable Root access'
-            Effect: Allow
-            Principal:
-              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
-            Action:
-              - 'kms:*'
-            Resource: '*'
-      Tags:
-        - Key: "jwkset"
-          Value: "true"
-        - Key: "awsStackName"
-          Value: !Sub "${AWS::StackName}"
-
-  DecryptionKeyAlias:
-    Type: AWS::KMS::Alias
-    Properties:
-      AliasName: !Sub alias/${AWS::StackName}/${Environment}/KBVCriDecryptionKey
-      TargetKeyId: !Ref KBVCriDecryptionKey
-
   KBVTable:
     Type: "AWS::DynamoDB::Table"
     Properties:
@@ -382,7 +338,7 @@ Resources:
               - "subject"
             ProjectionType: "INCLUDE"
       TimeToLiveSpecification:
-        AttributeName: expiry-date
+        AttributeName: expiryDate
         Enabled: true
 
   PersonIdentityTable:
@@ -567,7 +523,7 @@ Resources:
   KBVCriAudienceParameter:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: !Sub "/${AWS::StackName}/AddressCriAudience"
+      Name: !Sub "/${AWS::StackName}/KBVCriAudience"
       Type: String
       Value: !FindInMap [KBVCriAudienceMapping, Environment, !Ref 'Environment']
       Description: The kbv credential issuer (audience) identifier
@@ -577,7 +533,7 @@ Resources:
     Properties:
       Name: !Sub "/${AWS::StackName}/AuthRequestKmsEncryptionKeyId"
       Type: String
-      Value: !Ref KBVCriDecryptionKey
+      Value: !ImportValue core-infrastructure-CriDecryptionKey1Id
       Description: The (KMS) encryption key identifier for decrypting authorisation requests
 
   VerifiableCredentialIssuerParameter:
@@ -593,7 +549,7 @@ Resources:
     Properties:
       Name: !Sub "/${AWS::StackName}/verifiableCredentialKmsSigningKeyId"
       Type: String
-      Value: !Ref KBVCriVcSigningKey
+      Value: !ImportValue core-infrastructure-CriVcSigningKey1Id
       Description: Verifiable Credential Key Id
 
 

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -373,29 +373,17 @@ Resources:
         BurstLimit: 100 # requests the API can handle concurrently
         RateLimit: 50 # allowed requests per second
 
-  ApiKey1:
-    Type: AWS::ApiGateway::ApiKey
-    Properties:
-      Description: Api key 1
-      Enabled: true
-
-  ApiKey2:
-    Type: AWS::ApiGateway::ApiKey
-    Properties:
-      Description: Api key 2
-      Enabled: true
-
   LinkUsagePlanApiKey1:
     Type: AWS::ApiGateway::UsagePlanKey
     Properties:
-      KeyId: !Ref ApiKey1
+      KeyId: !ImportValue core-infrastructure-ApiKey1
       KeyType: API_KEY
       UsagePlanId: !Ref ApiUsagePlan
 
   LinkUsagePlanApiKey2:
     Type: AWS::ApiGateway::UsagePlanKey
     Properties:
-      KeyId: !Ref ApiKey2
+      KeyId: !ImportValue core-infrastructure-ApiKey2
       KeyType: API_KEY
       UsagePlanId: !Ref ApiUsagePlan
 


### PR DESCRIPTION
KBV CRI needs to have the `/question` and `/answer` endpoints to interact with the Experian SOAP endpoints for a KBV CRI journey

## Proposed changes
- Changes made to the `template.yaml` file to include the `question` endpoint
- Changes made to the `api.yaml` file to include schema objects
- General code changes in the handler/service areas and fixing broken unit tests

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-405](https://govukverify.atlassian.net/browse/KBV-405)

## Checklists
- Reusing the common Session endpoint and the `Session` table
- Reusing the common `PersonIdentity` table

### Environment variables or secrets
Added the Experian `keystore` and `keystore-password` via `template.yaml` in AWS - Secrets manager with following keys:
- /dev/di-ipv-cri-experian-kbv-api/experian/keystore-password
- /dev/di-ipv-cri-experian-kbv-api/experian/keystore