### PR TITLE
Configure question and answer endpoint in KBV CRI

### DIFF
--- a/infrastructure/lambda/api.yaml
+++ b/infrastructure/lambda/api.yaml
@@ -77,6 +77,39 @@ paths:
           Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${KBVQuestionFunction.Arn}/invocations"
         passthroughBehavior: "when_no_match"
 
+  /answer:
+    post:
+      parameters:
+        - $ref: "#/components/parameters/SessionHeader"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Answer"
+        required: true
+      responses:
+        "200":
+          description: "200 response"
+        "400":
+          description: "400 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: "500 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+      x-amazon-apigateway-request-validator: "Validate both"
+      x-amazon-apigateway-integration:
+        type: "aws_proxy"
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${KBVAnswerFunction.Arn}/invocations"
+        passthroughBehavior: "when_no_match"
+
 components:
   parameters:
     SessionHeader:
@@ -176,6 +209,17 @@ components:
           type: array
           items:
             type: "string"
+    Answer:
+      type: "object"
+      properties:
+        questionId:
+          description: The unique identifier for the question
+          maxLength: 6
+          type: "string"
+        answer:
+          description: Answer provided by the user
+          maxLength: 50
+          type: "string"
     Address:
       title: "Address Update Request"
       type: "array"

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -290,6 +290,48 @@ Resources:
               Resource:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/clients/*"
 
+  KBVAnswerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../../lambdas/answer/build/distributions/answer.zip
+      Handler: uk.gov.di.ipv.cri.kbv.api.handler.QuestionAnswerHandler::handleRequest
+      Environment:
+        Variables:
+          POWERTOOLS_METRICS_NAMESPACE: di-ipv-cri-kbv-api
+          POWERTOOLS_SERVICE_NAME: di-ipv-cri-kbv-api
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - AWSXrayWriteOnlyAccess
+        - DynamoDBReadPolicy:
+            TableName: !Ref KBVTable
+        - DynamoDBWritePolicy:
+            TableName: !Ref KBVTable
+        - DynamoDBReadPolicy:
+            TableName: !Ref SessionTable
+        - DynamoDBWritePolicy:
+            TableName: !Ref SessionTable
+        - Statement:
+            - Effect: Allow
+              Action:
+                - ssm:GetParameter
+              Resource:
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/KBVTableName"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/SessionTableName"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/SessionTtl"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/PersonIdentityTableName"
+        - Statement:
+            - Sid: ReadSecretsPolicy
+              Effect: Allow
+              Action:
+                - 'secretsmanager:GetSecretValue'
+              Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${Environment}/di-ipv-cri-experian-kbv-api/experian*'
+        - Statement:
+            - Effect: Allow
+              Action:
+                - ssm:GetParametersByPath
+              Resource:
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/clients/*"
+
   KBVTable:
     Type: "AWS::DynamoDB::Table"
     Properties:
@@ -565,6 +607,13 @@ Resources:
     Properties:
       Action: lambda:InvokeFunction
       FunctionName: !GetAtt KBVQuestionFunction.Arn
+      Principal: apigateway.amazonaws.com
+
+  KBVAnswerFunctionPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !GetAtt KBVAnswerFunction.Arn
       Principal: apigateway.amazonaws.com
 
 Outputs:

--- a/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
+++ b/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
@@ -13,6 +13,8 @@ import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.metrics.Metrics;
 import software.amazon.lambda.powertools.parameters.ParamManager;
 import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
+import uk.gov.di.ipv.cri.common.library.service.SessionService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswer;
@@ -39,6 +41,7 @@ public class QuestionAnswerHandler
     private final ObjectMapper objectMapper;
     private final KBVService kbvService;
     private final KBVStorageService kbvStorageService;
+    private final SessionService sessionService;
     private APIGatewayProxyResponseEvent response;
     public static final String HEADER_SESSION_ID = "session-id";
     public static final String ERROR_KEY = "\"error\"";
@@ -53,6 +56,7 @@ public class QuestionAnswerHandler
 
         this.response = new APIGatewayProxyResponseEvent();
         this.eventProbe = new EventProbe();
+        this.sessionService = new SessionService();
 
         var kbvSystemProperty =
                 new KBVSystemProperty(new KeyStoreService(ParamManager.getSecretsProvider()));
@@ -65,14 +69,15 @@ public class QuestionAnswerHandler
             KBVStorageService kbvStorageService,
             KBVSystemProperty systemProperty,
             KBVServiceFactory kbvServiceFactory,
-            EventProbe eventProbe) {
+            EventProbe eventProbe,
+            SessionService sessionService) {
         this.objectMapper = objectMapper;
         this.objectMapper.registerModule(new JavaTimeModule());
         this.kbvStorageService = kbvStorageService;
 
         this.response = new APIGatewayProxyResponseEvent();
         this.eventProbe = eventProbe;
-
+        this.sessionService = sessionService;
         this.kbvService = kbvServiceFactory.create();
         systemProperty.save();
     }
@@ -122,8 +127,7 @@ public class QuestionAnswerHandler
         QuestionState questionState;
         String sessionId = input.getHeaders().get(HEADER_SESSION_ID);
 
-        KBVItem kbvItem =
-                kbvStorageService.getSessionId(sessionId).orElseThrow(NullPointerException::new);
+        KBVItem kbvItem = kbvStorageService.getKBVItem(sessionId);
 
         questionState = objectMapper.readValue(kbvItem.getQuestionState(), QuestionState.class);
         QuestionAnswer answer = objectMapper.readValue(input.getBody(), QuestionAnswer.class);
@@ -148,9 +152,12 @@ public class QuestionAnswerHandler
         } else if (questionsResponse.hasQuestionRequestEnded()) {
             String state = objectMapper.writeValueAsString(questionState);
             kbvItem.setQuestionState(state);
-            kbvItem.setAuthorizationCode(UUID.randomUUID().toString());
             kbvItem.setStatus(questionsResponse.getStatus());
             kbvStorageService.update(kbvItem);
+
+            SessionItem sessionItem = sessionService.getSession(kbvItem.getSessionId());
+            sessionItem.setAuthorizationCode(UUID.randomUUID().toString());
+            sessionService.createAuthorizationCode(sessionItem);
         } else {
             // TODO: alternate flow could end of transaction / or others
         }

--- a/lambdas/answer/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandlerTest.java
+++ b/lambdas/answer/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandlerTest.java
@@ -13,6 +13,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.http.HttpStatusCode;
 import software.amazon.awssdk.services.dynamodb.model.InternalServerErrorException;
+import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
+import uk.gov.di.ipv.cri.common.library.service.SessionService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswer;
@@ -25,7 +27,6 @@ import uk.gov.di.ipv.cri.kbv.api.service.KBVSystemProperty;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
 
@@ -55,6 +56,7 @@ class QuestionAnswerHandlerTest {
     @Mock private Context contextMock;
     @Mock private EventProbe mockEventProbe;
     @Mock private KBVServiceFactory mockKbvServiceFactory;
+    @Mock private SessionService mockSessionService;
 
     @Mock private KBVService mockKbvService;
     @Mock private KBVSystemProperty mockSystemProperty;
@@ -69,7 +71,8 @@ class QuestionAnswerHandlerTest {
                         mockKBVStorageService,
                         mockSystemProperty,
                         mockKbvServiceFactory,
-                        mockEventProbe);
+                        mockEventProbe,
+                        mockSessionService);
     }
 
     @Test
@@ -80,9 +83,9 @@ class QuestionAnswerHandlerTest {
         QuestionState questionStateMock = mock(QuestionState.class);
 
         when(input.getHeaders()).thenReturn(sessionHeader);
-        when(mockKBVStorageService.getSessionId(
+        when(mockKBVStorageService.getKBVItem(
                         sessionHeader.get(QuestionAnswerHandler.HEADER_SESSION_ID)))
-                .thenReturn(Optional.ofNullable(kbvItemMock));
+                .thenReturn(kbvItemMock);
         when(mockObjectMapper.readValue(kbvItemMock.getQuestionState(), QuestionState.class))
                 .thenReturn(questionStateMock);
         when(input.getBody()).thenReturn(REQUEST_PAYLOAD);
@@ -105,14 +108,17 @@ class QuestionAnswerHandlerTest {
         QuestionState questionStateMock = mock(QuestionState.class);
         QuestionAnswer questionAnswerMock = mock(QuestionAnswer.class);
 
+        String mockUUID = UUID.randomUUID().toString();
         Map<String, String> sessionHeader =
-                Map.of(QuestionAnswerHandler.HEADER_SESSION_ID, UUID.randomUUID().toString());
+                Map.of(QuestionAnswerHandler.HEADER_SESSION_ID, mockUUID);
         QuestionsResponse questionsResponseMock = mock(QuestionsResponse.class);
 
         when(input.getHeaders()).thenReturn(sessionHeader);
-        when(mockKBVStorageService.getSessionId(
+        when(kbvItemMock.getSessionId())
+                .thenReturn(sessionHeader.get(QuestionAnswerHandler.HEADER_SESSION_ID));
+        when(mockKBVStorageService.getKBVItem(
                         sessionHeader.get(QuestionAnswerHandler.HEADER_SESSION_ID)))
-                .thenReturn(Optional.ofNullable(kbvItemMock));
+                .thenReturn(kbvItemMock);
 
         when(mockObjectMapper.readValue(kbvItemMock.getQuestionState(), QuestionState.class))
                 .thenReturn(questionStateMock);
@@ -128,10 +134,16 @@ class QuestionAnswerHandlerTest {
         when(questionsResponseMock.hasQuestions()).thenReturn(false);
         when(questionsResponseMock.hasQuestionRequestEnded()).thenReturn(true);
 
+        SessionItem mockSessionItem = mock(SessionItem.class);
+        when(mockSessionService.getSession(kbvItemMock.getSessionId())).thenReturn(mockSessionItem);
+        doNothing().when(mockSessionService).createAuthorizationCode(mockSessionItem);
+
         APIGatewayProxyResponseEvent result =
                 questionAnswerHandler.handleRequest(input, contextMock);
 
         verify(mockKBVStorageService, times(2)).update(kbvItemMock);
+        verify(mockSessionService).getSession(kbvItemMock.getSessionId());
+        verify(mockSessionService).createAuthorizationCode(mockSessionItem);
         assertEquals(HttpStatusCode.OK, result.getStatusCode());
         assertNull(result.getBody());
     }
@@ -147,9 +159,10 @@ class QuestionAnswerHandlerTest {
         QuestionsResponse questionsResponseMock = mock(QuestionsResponse.class);
 
         when(input.getHeaders()).thenReturn(sessionHeader);
-        when(mockKBVStorageService.getSessionId(
+
+        when(mockKBVStorageService.getKBVItem(
                         sessionHeader.get(QuestionAnswerHandler.HEADER_SESSION_ID)))
-                .thenReturn(Optional.ofNullable(kbvItemMock));
+                .thenReturn(kbvItemMock);
 
         when(mockObjectMapper.readValue(kbvItemMock.getQuestionState(), QuestionState.class))
                 .thenReturn(questionStateMock);
@@ -168,6 +181,7 @@ class QuestionAnswerHandlerTest {
                 questionAnswerHandler.handleRequest(input, contextMock);
 
         verify(mockKBVStorageService, times(2)).update(kbvItemMock);
+
         assertEquals(HttpStatusCode.OK, result.getStatusCode());
         assertNull(result.getBody());
     }
@@ -180,7 +194,7 @@ class QuestionAnswerHandlerTest {
         when(input.getHeaders()).thenReturn(sessionHeader);
         doThrow(InternalServerErrorException.class)
                 .when(mockKBVStorageService)
-                .getSessionId(anyString());
+                .getKBVItem(anyString());
 
         setupEventProbeErrorBehaviour();
         APIGatewayProxyResponseEvent response =
@@ -207,24 +221,23 @@ class QuestionAnswerHandlerTest {
     void shouldReturn500ErrorWhenQuestionStateCannotBeParsedToJSON() throws IOException {
         Map<String, String> sessionHeader =
                 Map.of(QuestionAnswerHandler.HEADER_SESSION_ID, UUID.randomUUID().toString());
-        KBVItem kbvSessionItemMock = mock(KBVItem.class);
+        KBVItem kbvItemMock = mock(KBVItem.class);
 
         when(input.getHeaders()).thenReturn(sessionHeader);
-        when(mockKBVStorageService.getSessionId(
+
+        when(mockKBVStorageService.getKBVItem(
                         sessionHeader.get(QuestionAnswerHandler.HEADER_SESSION_ID)))
-                .thenReturn(Optional.ofNullable(kbvSessionItemMock));
-        //        when(mockObjectMapper.readValue(kbvSessionItemMock.getQuestionState(),
-        // QuestionState.class))
-        //                .thenThrow(JsonProcessingException.class);
+                .thenReturn(kbvItemMock);
+        when(mockObjectMapper.readValue(kbvItemMock.getQuestionState(), QuestionState.class))
+                .thenThrow(JsonProcessingException.class);
         setupEventProbeErrorBehaviour();
         APIGatewayProxyResponseEvent response =
                 questionAnswerHandler.handleRequest(input, contextMock);
 
-        //        assertEquals(
-        //                "{ \"error\":\"Failed to parse object using ObjectMapper.\" }",
-        // response.getBody());
-        //        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatusCode());
-        //        verify(mockEventProbe).counterMetric("post_answer", 0d);
+        assertEquals(
+                "{ \"error\":\"Failed to parse object using ObjectMapper.\" }", response.getBody());
+        assertEquals(HttpStatusCode.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        verify(mockEventProbe).counterMetric("post_answer", 0d);
     }
 
     @Test
@@ -235,9 +248,9 @@ class QuestionAnswerHandlerTest {
         Map<String, String> sessionHeader =
                 Map.of(QuestionAnswerHandler.HEADER_SESSION_ID, UUID.randomUUID().toString());
         when(input.getHeaders()).thenReturn(sessionHeader);
-        when(mockKBVStorageService.getSessionId(
+        when(mockKBVStorageService.getKBVItem(
                         sessionHeader.get(QuestionAnswerHandler.HEADER_SESSION_ID)))
-                .thenReturn(Optional.ofNullable(kbvItemMock));
+                .thenReturn(kbvItemMock);
 
         QuestionAnswer questionAnswerMock = mock(QuestionAnswer.class);
 
@@ -258,7 +271,8 @@ class QuestionAnswerHandlerTest {
                         mockKBVStorageService,
                         mockSystemProperty,
                         factory,
-                        mockEventProbe);
+                        mockEventProbe,
+                        mockSessionService);
 
         Exception unExpectedException = new Exception();
         assertThrows(

--- a/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
+++ b/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
@@ -314,7 +314,7 @@ class QuestionHandlerTest {
         when(mockObjectMapper.readValue(SessionItemMock.getQuestionState(), QuestionState.class))
                 .thenReturn(questionStateMock);
 
-        when(SessionItemMock.getAuthorizationCode()).thenReturn("authorisation-code");
+        when(SessionItemMock.getStatus()).thenReturn("status-code");
         APIGatewayProxyResponseEvent response = questionHandler.handleRequest(input, contextMock);
 
         assertEquals(HttpStatusCode.NO_CONTENT, response.getStatusCode());

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/KBVItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/KBVItem.java
@@ -6,18 +6,12 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbParti
 @DynamoDbBean
 public class KBVItem {
     private String sessionId;
-    private String authorizationCode;
     private String token;
     private String questionState;
     private String expiryDate;
     private String authRefNo;
     private String urn;
-    private String userAttributes;
     private String status;
-
-    public void setAuthorizationCode(String authorizationCode) {
-        this.authorizationCode = authorizationCode;
-    }
 
     public void setToken(String token) {
         this.token = token;
@@ -37,10 +31,6 @@ public class KBVItem {
 
     public String getQuestionState() {
         return questionState;
-    }
-
-    public String getAuthorizationCode() {
-        return authorizationCode;
     }
 
     public String getExpiryDate() {
@@ -65,14 +55,6 @@ public class KBVItem {
 
     public void setUrn(String urn) {
         this.urn = urn;
-    }
-
-    public String getUserAttributes() {
-        return userAttributes;
-    }
-
-    public void setUserAttributes(String userAttributes) {
-        this.userAttributes = userAttributes;
     }
 
     @DynamoDbPartitionKey

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/KBVStorageService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/KBVStorageService.java
@@ -4,6 +4,7 @@ import software.amazon.lambda.powertools.parameters.ParamManager;
 import uk.gov.di.ipv.cri.common.library.persistence.DataStore;
 import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
 
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -20,11 +21,20 @@ public class KBVStorageService {
     }
 
     public Optional<KBVItem> getSessionId(String sessionId) {
-        return Optional.of(dataStore.getItem(sessionId));
+        return Optional.of(this.dataStore.getItem(sessionId));
+    }
+
+    public KBVItem getKBVItem(String sessionId) {
+        return this.dataStore.getItem(sessionId);
     }
 
     public void update(KBVItem kbvItem) {
         dataStore.update(kbvItem);
+    }
+
+    public void save(KBVItem kbvItem) {
+        kbvItem.setExpiryDate(Instant.now().getEpochSecond() + "");
+        dataStore.create(kbvItem);
     }
 
     public String getKBVTableName() {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/KBVStorageService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/KBVStorageService.java
@@ -4,7 +4,6 @@ import software.amazon.lambda.powertools.parameters.ParamManager;
 import uk.gov.di.ipv.cri.common.library.persistence.DataStore;
 import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
 
-import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -33,7 +32,6 @@ public class KBVStorageService {
     }
 
     public void save(KBVItem kbvItem) {
-        kbvItem.setExpiryDate(Instant.now().getEpochSecond() + "");
         dataStore.create(kbvItem);
     }
 


### PR DESCRIPTION
KBV CRI needs to have the `/question` and `/answer` endpoints to interact with the Experian SOAP endpoints for a KBV CRI journey

## Proposed changes
- Changes made to the `template.yaml` file to include the `answer` endpoint
- Changes made to the `api.yaml` file to schema objects
- General code changes in the handler/service areas and fixing broken unit tests

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-406](https://govukverify.atlassian.net/browse/KBV-406)
- [KBV-405](https://govukverify.atlassian.net/browse/KBV-405)

## Checklists
- Reusing the common Session endpoint and the `Session` table
- Reusing the common `PersonIdentity` table

### Environment variables or secrets
Added the Experian `keystore` and `keystore-password` via `template.yaml` in AWS - Secrets manager with following keys:
- /dev/di-ipv-cri-experian-kbv-api/experian/keystore-password
- /dev/di-ipv-cri-experian-kbv-api/experian/keystore