### PR TITLE
KBV-510 Allow issue credential function to read PersonIdentityTable in DDB

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -432,6 +432,8 @@ Resources:
             TableName: !Ref SessionTable
         - DynamoDBReadPolicy:
             TableName: !Ref KBVTable
+        - DynamoDBReadPolicy:
+            TableName: !Ref PersonIdentityTable
         - Statement:
             Effect: Allow
             Action:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Allow issue credential function to read PersonIdentityTable in DDB.

This is a policy that the Address CRI never needed as there are no user attributes to read out when creating the Address VC.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-510](https://govukverify.atlassian.net/browse/KBV-510)
