### PR TITLE
KBV-510 Prefix secrets with stack name only

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -344,7 +344,7 @@ Resources:
               Effect: Allow
               Action:
                 - 'secretsmanager:GetSecretValue'
-              Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${Environment}/kbv-cri-api/experian*'
+              Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${AWS::StackName}/experian*'
         - Statement:
             - Effect: Allow
               Action:
@@ -399,7 +399,7 @@ Resources:
               Effect: Allow
               Action:
                 - 'secretsmanager:GetSecretValue'
-              Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${Environment}/kbv-cri-api/experian*'
+              Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${AWS::StackName}/experian*'
         - Statement:
             - Effect: Allow
               Action:

--- a/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
+++ b/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
@@ -21,6 +21,7 @@ import uk.gov.di.ipv.cri.common.library.service.AuditService;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.common.library.service.SessionService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
+import uk.gov.di.ipv.cri.kbv.api.config.ConfigurationConstants;
 import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswer;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswerRequest;
@@ -64,7 +65,10 @@ public class QuestionAnswerHandler
                         SqsClient.builder().build(), new ConfigurationService(), this.objectMapper);
 
         var kbvSystemProperty =
-                new KBVSystemProperty(new KeyStoreService(ParamManager.getSecretsProvider()));
+                new KBVSystemProperty(
+                        new KeyStoreService(
+                                ParamManager.getSecretsProvider(),
+                                System.getenv(ConfigurationConstants.AWS_STACK_NAME)));
 
         kbvSystemProperty.save();
     }

--- a/lambdas/question/src/main/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandler.java
+++ b/lambdas/question/src/main/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandler.java
@@ -22,6 +22,7 @@ import uk.gov.di.ipv.cri.common.library.service.AuditService;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.common.library.service.PersonIdentityService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
+import uk.gov.di.ipv.cri.kbv.api.config.ConfigurationConstants;
 import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionRequest;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionState;
@@ -73,7 +74,10 @@ public class QuestionHandler
         this.clock = Clock.systemUTC();
 
         var kbvSystemProperty =
-                new KBVSystemProperty(new KeyStoreService(ParamManager.getSecretsProvider()));
+                new KBVSystemProperty(
+                        new KeyStoreService(
+                                ParamManager.getSecretsProvider(),
+                                System.getenv(ConfigurationConstants.AWS_STACK_NAME)));
         kbvSystemProperty.save();
     }
 

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/config/ConfigurationConstants.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/config/ConfigurationConstants.java
@@ -1,0 +1,5 @@
+package uk.gov.di.ipv.cri.kbv.api.config;
+
+public class ConfigurationConstants {
+    public static final String AWS_STACK_NAME = "AWS_STACK_NAME";
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/KeyStoreService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/KeyStoreService.java
@@ -3,23 +3,34 @@ package uk.gov.di.ipv.cri.kbv.api.service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.lambda.powertools.parameters.SecretsProvider;
+import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Base64;
+import java.util.Objects;
 import java.util.UUID;
 
 public class KeyStoreService {
     private final SecretsProvider secretsProvider;
-    public static final String KBV_API_KEYSTORE = "/dev/kbv-cri-api/experian/keystore";
-    public static final String KBV_API_KEYSTORE_PASSWORD =
-            "/dev/kbv-cri-api/experian/keystore-password";
+    public static final String KBV_API_KEYSTORE_SUFFIX = "/experian/keystore";
+    public static final String KBV_API_KEYSTORE_PASSWORD_SUFFIX = "/experian/keystore-password";
     private static final Logger LOGGER = LoggerFactory.getLogger(KeyStoreService.class);
+    private final String stackName;
 
+    public KeyStoreService(SecretsProvider secretsProvider, String stackName) {
+        this.secretsProvider = secretsProvider;
+        this.stackName = stackName;
+    }
+
+    @ExcludeFromGeneratedCoverageReport
     public KeyStoreService(SecretsProvider secretsProvider) {
         this.secretsProvider = secretsProvider;
+        this.stackName =
+                Objects.requireNonNull(
+                        System.getenv("AWS_STACK_NAME"), "env var AWS_STACK_NAME required");
     }
 
     public String getKeyStorePath() {
@@ -27,7 +38,9 @@ public class KeyStoreService {
             File file = Files.createTempFile(UUID.randomUUID().toString(), ".tmp").toFile();
             Path tempFile = file.toPath();
             Files.write(
-                    tempFile, Base64.getDecoder().decode(secretsProvider.get(KBV_API_KEYSTORE)));
+                    tempFile,
+                    Base64.getDecoder()
+                            .decode(secretsProvider.get(getSecretPath(KBV_API_KEYSTORE_SUFFIX))));
             return tempFile.toString();
         } catch (IllegalArgumentException | NullPointerException | IOException e) {
             LOGGER.error("Initialisation failed", e);
@@ -36,6 +49,10 @@ public class KeyStoreService {
     }
 
     public String getPassword() {
-        return secretsProvider.get(KBV_API_KEYSTORE_PASSWORD);
+        return secretsProvider.get(getSecretPath(KBV_API_KEYSTORE_PASSWORD_SUFFIX));
+    }
+
+    private String getSecretPath(String suffix) {
+        return String.format("/%s%s", stackName, suffix);
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/KeyStoreServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/KeyStoreServiceTest.java
@@ -11,8 +11,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.cri.kbv.api.service.KeyStoreService.KBV_API_KEYSTORE;
-import static uk.gov.di.ipv.cri.kbv.api.service.KeyStoreService.KBV_API_KEYSTORE_PASSWORD;
+import static uk.gov.di.ipv.cri.kbv.api.service.KeyStoreService.KBV_API_KEYSTORE_PASSWORD_SUFFIX;
+import static uk.gov.di.ipv.cri.kbv.api.service.KeyStoreService.KBV_API_KEYSTORE_SUFFIX;
 
 @ExtendWith(MockitoExtension.class)
 class KeyStoreServiceTest {
@@ -23,12 +23,13 @@ class KeyStoreServiceTest {
 
     @BeforeEach
     void setUp() {
-        this.keyStoreService = new KeyStoreService(secretsProvider);
+        this.keyStoreService = new KeyStoreService(secretsProvider, "stack-name");
     }
 
     @Test
     void shouldReturnKeyStoreValueWhenSecretIsRetrieved() {
-        when(secretsProvider.get(KBV_API_KEYSTORE)).thenReturn(BASE64_KEYSTORE_VALUE);
+        when(secretsProvider.get("/stack-name" + KBV_API_KEYSTORE_SUFFIX))
+                .thenReturn(BASE64_KEYSTORE_VALUE);
 
         assertNotNull(keyStoreService.getKeyStorePath());
     }
@@ -42,7 +43,8 @@ class KeyStoreServiceTest {
 
     @Test
     void shouldReturnKeyStorePasswordWhenSecretIsRetrieved() {
-        when(secretsProvider.get(KBV_API_KEYSTORE_PASSWORD)).thenReturn(BASE64_KEYSTORE_PASSWORD);
+        when(secretsProvider.get("/stack-name" + KBV_API_KEYSTORE_PASSWORD_SUFFIX))
+                .thenReturn(BASE64_KEYSTORE_PASSWORD);
 
         assertEquals("keystore-password", keyStoreService.getPassword());
     }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/KeyStoreServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/KeyStoreServiceTest.java
@@ -11,24 +11,26 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.cri.kbv.api.service.KeyStoreService.KBV_API_KEYSTORE_PASSWORD_SUFFIX;
-import static uk.gov.di.ipv.cri.kbv.api.service.KeyStoreService.KBV_API_KEYSTORE_SUFFIX;
 
 @ExtendWith(MockitoExtension.class)
 class KeyStoreServiceTest {
-    public static final String BASE64_KEYSTORE_VALUE = "a2V5c3RvcmUtdmFsdWU=";
-    public static final String BASE64_KEYSTORE_PASSWORD = "keystore-password";
+    private static final String BASE64_KEYSTORE_VALUE = "a2V5c3RvcmUtdmFsdWU=";
+    private static final String BASE64_KEYSTORE_PASSWORD = "keystore-password";
+    private static final String TEST_STACK_NAME = "stack-name";
+    private static final String SECRET_KEY_FORMAT = "/%s/%s";
+
+    @Mock private SecretsProvider secretsProvider;
     private KeyStoreService keyStoreService;
-    @Mock SecretsProvider secretsProvider;
 
     @BeforeEach
     void setUp() {
-        this.keyStoreService = new KeyStoreService(secretsProvider, "stack-name");
+        this.keyStoreService = new KeyStoreService(secretsProvider, TEST_STACK_NAME);
     }
 
     @Test
     void shouldReturnKeyStoreValueWhenSecretIsRetrieved() {
-        when(secretsProvider.get("/stack-name" + KBV_API_KEYSTORE_SUFFIX))
+        when(secretsProvider.get(
+                        String.format(SECRET_KEY_FORMAT, TEST_STACK_NAME, "experian/keystore")))
                 .thenReturn(BASE64_KEYSTORE_VALUE);
 
         assertNotNull(keyStoreService.getKeyStorePath());
@@ -36,14 +38,14 @@ class KeyStoreServiceTest {
 
     @Test
     void shouldReturnNullWhenKeyStoreValueIsNotSupplied() {
-        keyStoreService.getKeyStorePath();
-
         assertNull(keyStoreService.getKeyStorePath());
     }
 
     @Test
     void shouldReturnKeyStorePasswordWhenSecretIsRetrieved() {
-        when(secretsProvider.get("/stack-name" + KBV_API_KEYSTORE_PASSWORD_SUFFIX))
+        when(secretsProvider.get(
+                        String.format(
+                                SECRET_KEY_FORMAT, TEST_STACK_NAME, "experian/keystore-password")))
                 .thenReturn(BASE64_KEYSTORE_PASSWORD);
 
         assertEquals("keystore-password", keyStoreService.getPassword());


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

* Remove hardcoded `/dev` prefix for secret names
* Evaluate stack name as prefix for secret name

ℹ️ I'll set these secrets for dev's stacks in `di-ipv-cri-dev` once approved, and pre-merge.

### Why did it change

* The harcoded secret names starting with `/dev` are inappropriate for KBV accounts besides dev.
* We may want different stacks on an account referencing different secrets e.g. a url that points to a mock IIQ service.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-510](https://govukverify.atlassian.net/browse/KBV-510)