### PR TITLE
[KVB-106] Fix error for mapping of List<Address> to Object[]

### DIFF
--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
@@ -1,11 +1,14 @@
 package uk.gov.di.ipv.cri.kbv.api.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
+import org.apache.logging.log4j.LogManager;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.BirthDate;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentityDetailed;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
@@ -19,7 +22,6 @@ import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static com.nimbusds.jwt.JWTClaimNames.EXPIRATION_TIME;
 import static com.nimbusds.jwt.JWTClaimNames.ISSUER;
@@ -80,7 +82,9 @@ public class VerifiableCredentialService {
                                         new String[] {W3_BASE_CONTEXT, DI_CONTEXT},
                                         VC_CREDENTIAL_SUBJECT,
                                         Map.of(
-                                                VC_ADDRESS_KEY, personIdentity.getAddresses(),
+                                                VC_ADDRESS_KEY,
+                                                        convertAddresses(
+                                                                personIdentity.getAddresses()),
                                                 VC_NAME_KEY, personIdentity.getNames(),
                                                 VC_BIRTHDATE_KEY,
                                                         convertBirthDates(
@@ -89,10 +93,24 @@ public class VerifiableCredentialService {
                                         calculateEvidence(kbvItem)))
                         .build();
 
+        var logger = LogManager.getLogger();
+
+        try {
+            logger.error(objectMapper.writeValueAsString(calculateEvidence(kbvItem)));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
         return signedJwtFactory.createSignedJwt(claimsSet);
     }
 
-    private List<Map<String, String>> convertBirthDates(List<BirthDate> birthDates) {
+    private Object[] convertAddresses(List<Address> addresses) {
+        return addresses.stream()
+                .map(address -> objectMapper.convertValue(address, Map.class))
+                .toArray();
+    }
+
+    private Object[] convertBirthDates(List<BirthDate> birthDates) {
         return birthDates.stream()
                 .map(
                         birthDate ->
@@ -101,7 +119,7 @@ public class VerifiableCredentialService {
                                         birthDate
                                                 .getValue()
                                                 .format(DateTimeFormatter.ISO_LOCAL_DATE)))
-                .collect(Collectors.toList());
+                .toArray();
     }
 
     private Map[] calculateEvidence(KBVItem kbvItem) {

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
@@ -1,13 +1,11 @@
 package uk.gov.di.ipv.cri.kbv.api.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
-import org.apache.logging.log4j.LogManager;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.BirthDate;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentityDetailed;
@@ -93,14 +91,6 @@ public class VerifiableCredentialService {
                                         calculateEvidence(kbvItem)))
                         .build();
 
-        var logger = LogManager.getLogger();
-
-        try {
-            logger.error(objectMapper.writeValueAsString(calculateEvidence(kbvItem)));
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
-
         return signedJwtFactory.createSignedJwt(claimsSet);
     }
 
@@ -122,7 +112,7 @@ public class VerifiableCredentialService {
                 .toArray();
     }
 
-    private Map[] calculateEvidence(KBVItem kbvItem) {
+    private Object[] calculateEvidence(KBVItem kbvItem) {
 
         Evidence evidence = new Evidence();
         evidence.setType(EvidenceType.IDENTITY_CHECK);

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialServiceTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialServiceTest.java
@@ -69,6 +69,8 @@ class VerifiableCredentialServiceTest implements TestFixtures {
 
         when(mockObjectMapper.convertValue(any(Evidence.class), eq(Map.class)))
                 .thenReturn(Map.of("verificationScore", 2));
+        when(mockObjectMapper.convertValue(any(Address.class), eq(Map.class)))
+                .thenReturn(Map.of("address", new Address()));
 
         KBVItem kbvItem = new KBVItem();
         kbvItem.setSessionId(UUID.randomUUID());
@@ -126,6 +128,9 @@ class VerifiableCredentialServiceTest implements TestFixtures {
                         signedJwtFactory, mockConfigurationService, mockObjectMapper);
         when(mockObjectMapper.convertValue(any(Evidence.class), eq(Map.class)))
                 .thenReturn(Map.of("verificationScore", 0));
+
+        when(mockObjectMapper.convertValue(any(Address.class), eq(Map.class)))
+                .thenReturn(Map.of("address", new Address()));
 
         KBVItem kbvItem = new KBVItem();
         kbvItem.setSessionId(UUID.randomUUID());


### PR DESCRIPTION
## Proposed changes

### What changed

Fix error for mapping of List<Address> to Object[] to make compatible with Nimbus claimset

### Why did it change

Nimbus and ClaimSets really do not like List<> passed to them as, when trying to parse things like Java 8 objects and times (LocalDate, LocalTime, Optional<> etc), it falls over as we're unable to pass through a custom ObjectMapper that we do elsewhere.

For this reason, we take matters into our own hands and use our own ObjectMapper to convert these to Object[] (essentially converting our classes into a Map using Jackson and injecting this into the ClaimSet as an array of Object

### Issue tracking
This (very loosely) tracks KBV-106, referenced below:

- [KBV-106](https://govukverify.atlassian.net/browse/KBV-106)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed