### PR TITLE
[KBV-512] Correct shape of Verifiable Credential

### DIFF
--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/Evidence.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/Evidence.java
@@ -2,7 +2,7 @@ package uk.gov.di.ipv.cri.kbv.api.domain;
 
 public class Evidence {
     private String txn;
-    private EvidenceType type;
+    private final String type = VerifiableCredentialConstants.VC_EVIDENCE_TYPE;
     private Integer verificationScore;
 
     public String getTxn() {
@@ -13,13 +13,11 @@ public class Evidence {
         this.txn = txn;
     }
 
-    public EvidenceType getType() {
+    public String getType() {
         return type;
     }
 
-    public void setType(EvidenceType type) {
-        this.type = type;
-    }
+    public void setType(String type) {}
 
     public Integer getVerificationScore() {
         return verificationScore;

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/Evidence.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/Evidence.java
@@ -1,8 +1,9 @@
 package uk.gov.di.ipv.cri.kbv.api.domain;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
+
 public class Evidence {
     private String txn;
-    private final String type = VerifiableCredentialConstants.VC_EVIDENCE_TYPE;
     private Integer verificationScore;
 
     public String getTxn() {
@@ -13,11 +14,10 @@ public class Evidence {
         this.txn = txn;
     }
 
+    @JsonGetter("type")
     public String getType() {
-        return type;
+        return VerifiableCredentialConstants.VC_EVIDENCE_TYPE;
     }
-
-    public void setType(String type) {}
 
     public Integer getVerificationScore() {
         return verificationScore;

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/EvidenceType.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/EvidenceType.java
@@ -1,5 +1,0 @@
-package uk.gov.di.ipv.cri.kbv.api.domain;
-
-public enum EvidenceType {
-    IDENTITY_CHECK
-}

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/VerifiableCredentialConstants.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/VerifiableCredentialConstants.java
@@ -8,7 +8,7 @@ public class VerifiableCredentialConstants {
     public static final String VC_TYPE = "type";
     public static final String VERIFIABLE_CREDENTIAL_TYPE = "VerifiableCredential";
 
-    public static final String KBV_CREDENTIAL_TYPE = "KBVCredential";
+    public static final String KBV_CREDENTIAL_TYPE = "IdentityCheckCredential";
     public static final String VC_CREDENTIAL_SUBJECT = "credentialSubject";
     public static final String VC_CLAIM = "vc";
 
@@ -19,6 +19,8 @@ public class VerifiableCredentialConstants {
     public static final String VC_NAME_KEY = "name";
 
     public static final String VC_EVIDENCE_KEY = "evidence";
+
+    public static final String VC_EVIDENCE_TYPE = "IdentityCheck";
 
     public static final String VC_THIRD_PARTY_KBV_CHECK_PASS = "AUTHENTICATED";
 


### PR DESCRIPTION
## Proposed changes

### What changed

- Drop @context
- evidence.type needs updating to “IdentityCheck“
- vc.type needs amending from “KBVCredential“ to “IdentityCheckCredential“
- Drop addressType from the address returned

### Why did it change

The Verifiable Credential was outputting some additional or incorrect information, which did not match the RFC

### Issue tracking

- [KBV-512](https://govukverify.atlassian.net/browse/KBV-512)
