### PR TITLE
KBV-508: Refactor questionhandler to not return void

### DIFF
--- a/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
+++ b/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
@@ -3,11 +3,14 @@ package uk.gov.di.ipv.cri.kbv.api.handler;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.experian.uk.schema.experian.identityiq.services.webservice.AnswerFormat;
 import com.experian.uk.schema.experian.identityiq.services.webservice.Control;
 import com.experian.uk.schema.experian.identityiq.services.webservice.Question;
+import com.experian.uk.schema.experian.identityiq.services.webservice.Questions;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.Level;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -26,6 +29,7 @@ import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.common.library.service.PersonIdentityService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
+import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswer;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionRequest;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionState;
 import uk.gov.di.ipv.cri.kbv.api.gateway.KBVGateway;
@@ -34,18 +38,23 @@ import uk.gov.di.ipv.cri.kbv.api.service.KBVService;
 import uk.gov.di.ipv.cri.kbv.api.service.KBVStorageService;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.cri.kbv.api.handler.QuestionHandler.GET_QUESTION;
@@ -77,252 +86,466 @@ class QuestionHandlerTest {
                         mockAuditService);
     }
 
-    @Test
-    void shouldReturn200OkWhen1stCalledAndReturn1stUnAnsweredQuestionFromExperianEndpoint()
-            throws IOException, SqsException {
-        APIGatewayProxyRequestEvent input = mock(APIGatewayProxyRequestEvent.class);
-        Map<String, String> sessionHeader = Map.of(HEADER_SESSION_ID, UUID.randomUUID().toString());
+    @Nested
+    class QuestionHandlerCalled {
+        @Test
+        void shouldReturn200OkWhen1stCalledAndReturn1stUnAnsweredQuestionFromExperianEndpoint()
+                throws IOException, SqsException {
+            APIGatewayProxyRequestEvent input = mock(APIGatewayProxyRequestEvent.class);
+            Map<String, String> sessionHeader =
+                    Map.of(HEADER_SESSION_ID, UUID.randomUUID().toString());
 
-        Context contextMock = mock(Context.class);
+            KBVItem kbvItem = new KBVItem();
+            kbvItem.setSessionId(UUID.fromString(sessionHeader.get(HEADER_SESSION_ID)));
+            PersonIdentity personIdentity = new PersonIdentity();
+
+            when(input.getHeaders()).thenReturn(sessionHeader);
+            when(mockPersonIdentityService.getPersonIdentity(kbvItem.getSessionId()))
+                    .thenReturn(personIdentity);
+            doNothing().when(mockAuditService).sendAuditEvent(AuditEventType.REQUEST_SENT);
+            doNothing().when(mockKBVStorageService).save(any());
+
+            String expectedQuestion = new ObjectMapper().writeValueAsString(getQuestionOne());
+
+            doReturn(getExperianQuestionResponse(List.of(getQuestionOne(), getQuestionTwo())))
+                    .when(spyKBVService)
+                    .getQuestions(any());
+            when(mockObjectMapper.writeValueAsString(any())).thenReturn(expectedQuestion);
+            APIGatewayProxyResponseEvent response =
+                    questionHandler.handleRequest(input, mock(Context.class));
+
+            assertEquals(HttpStatusCode.OK, response.getStatusCode());
+            assertEquals(expectedQuestion, response.getBody());
+
+            verify(mockPersonIdentityService).getPersonIdentity(kbvItem.getSessionId());
+            verify(mockAuditService).sendAuditEvent(AuditEventType.REQUEST_SENT);
+            verify(mockKBVStorageService).save(any());
+            verify(mockObjectMapper, times(2)).writeValueAsString(any());
+            verify(mockEventProbe).counterMetric(GET_QUESTION);
+        }
+
+        @Test
+        void shouldReturn200OkWhenCalledAgainAndReturnNextUnAnsweredQuestionFromStorage()
+                throws IOException {
+            APIGatewayProxyRequestEvent input = mock(APIGatewayProxyRequestEvent.class);
+            Map<String, String> sessionHeader =
+                    Map.of(HEADER_SESSION_ID, UUID.randomUUID().toString());
+
+            KBVItem kbvItem = new KBVItem();
+            kbvItem.setSessionId(UUID.fromString(sessionHeader.get(HEADER_SESSION_ID)));
+
+            QuestionState questionState = new QuestionState();
+            Questions questions = new Questions();
+
+            Question answeredQuestion = getQuestionOne();
+            QuestionAnswer questionAnswer = new QuestionAnswer();
+            questionAnswer.setQuestionId(answeredQuestion.getQuestionID());
+            questionAnswer.setAnswer("OVER £35,000 UP TO £60,000");
+
+            Question unAnsweredQuestion = getQuestionTwo();
+            questions.getQuestion().addAll(List.of(answeredQuestion, unAnsweredQuestion));
+
+            questionState.setQAPairs(questions);
+            questionState.setAnswer(questionAnswer);
+
+            when(input.getHeaders()).thenReturn(sessionHeader);
+            when(mockKBVStorageService.getKBVItem(
+                            UUID.fromString(sessionHeader.get(HEADER_SESSION_ID))))
+                    .thenReturn(kbvItem);
+            when(mockObjectMapper.readValue(kbvItem.getQuestionState(), QuestionState.class))
+                    .thenReturn(questionState);
+            String expectedQuestion = new ObjectMapper().writeValueAsString(unAnsweredQuestion);
+            when(mockObjectMapper.writeValueAsString(unAnsweredQuestion))
+                    .thenReturn(expectedQuestion);
+
+            APIGatewayProxyResponseEvent response =
+                    questionHandler.handleRequest(input, mock(Context.class));
+
+            assertEquals(HttpStatusCode.OK, response.getStatusCode());
+            assertEquals(expectedQuestion, response.getBody());
+            verify(mockKBVStorageService)
+                    .getKBVItem(UUID.fromString(sessionHeader.get(HEADER_SESSION_ID)));
+            verify(mockObjectMapper).readValue(kbvItem.getQuestionState(), QuestionState.class);
+            verify(mockObjectMapper).writeValueAsString(unAnsweredQuestion);
+            verify(mockEventProbe).counterMetric(GET_QUESTION);
+        }
+
+        @Test
+        void shouldReturn400ErrorWhenNoFurtherQuestions() throws IOException {
+            Context contextMock = mock(Context.class);
+            APIGatewayProxyRequestEvent input = mock(APIGatewayProxyRequestEvent.class);
+            Map<String, String> sessionHeader =
+                    Map.of(HEADER_SESSION_ID, UUID.randomUUID().toString());
+
+            PersonIdentity personIdentity = new PersonIdentity();
+            KBVItem kbvItem = new KBVItem();
+            kbvItem.setSessionId(UUID.fromString(sessionHeader.get(HEADER_SESSION_ID)));
+            QuestionState questionStateMock = mock(QuestionState.class);
+
+            when(input.getHeaders()).thenReturn(sessionHeader);
+            when(mockKBVStorageService.getKBVItem(
+                            UUID.fromString(sessionHeader.get(HEADER_SESSION_ID))))
+                    .thenReturn(kbvItem);
+            when(mockPersonIdentityService.getPersonIdentity(kbvItem.getSessionId()))
+                    .thenReturn(personIdentity);
+
+            when(mockObjectMapper.readValue(kbvItem.getQuestionState(), QuestionState.class))
+                    .thenReturn(questionStateMock);
+
+            APIGatewayProxyResponseEvent response =
+                    questionHandler.handleRequest(input, contextMock);
+
+            assertEquals(HttpStatusCode.BAD_REQUEST, response.getStatusCode());
+
+            verify(mockKBVStorageService)
+                    .getKBVItem(UUID.fromString(sessionHeader.get(HEADER_SESSION_ID)));
+
+            verify(mockPersonIdentityService).getPersonIdentity(kbvItem.getSessionId());
+            verify(mockObjectMapper).readValue(kbvItem.getQuestionState(), QuestionState.class);
+            verify(mockEventProbe).counterMetric(GET_QUESTION);
+        }
+
+        @Test
+        void shouldReturn400ErrorWhenNoSessionIdProvided() {
+            APIGatewayProxyRequestEvent input = mock(APIGatewayProxyRequestEvent.class);
+            setupEventProbeErrorBehaviour();
+
+            APIGatewayProxyResponseEvent response =
+                    questionHandler.handleRequest(input, mock(Context.class));
+
+            String expectedMessage = "java.lang.NullPointerException";
+            assertTrue(response.getBody().contains(expectedMessage));
+            assertEquals(HttpStatusCode.BAD_REQUEST, response.getStatusCode());
+            verify(mockEventProbe).counterMetric(GET_QUESTION, 0d);
+        }
+
+        @Test
+        void shouldReturn500ErrorWhenAWSDynamoDBServiceDown() {
+            APIGatewayProxyRequestEvent input = mock(APIGatewayProxyRequestEvent.class);
+            Map<String, String> sessionHeader =
+                    Map.of(HEADER_SESSION_ID, UUID.randomUUID().toString());
+
+            when(input.getHeaders()).thenReturn(sessionHeader);
+            doThrow(InternalServerErrorException.class)
+                    .when(mockKBVStorageService)
+                    .getKBVItem(UUID.fromString(sessionHeader.get(HEADER_SESSION_ID)));
+
+            setupEventProbeErrorBehaviour();
+            APIGatewayProxyResponseEvent response =
+                    questionHandler.handleRequest(input, mock(Context.class));
+
+            assertEquals("{ \"error\":\"AWS Server error occurred.\" }", response.getBody());
+            assertEquals(HttpStatusCode.INTERNAL_SERVER_ERROR, response.getStatusCode());
+            verify(mockEventProbe).counterMetric(GET_QUESTION, 0d);
+        }
+
+        @Test
+        void shouldReturn500ErrorWhenPersonIdentityCannotBeRetrievedDueToAnAwsError() {
+            APIGatewayProxyRequestEvent input = mock(APIGatewayProxyRequestEvent.class);
+            Map<String, String> sessionHeader =
+                    Map.of(HEADER_SESSION_ID, UUID.randomUUID().toString());
+
+            when(input.getHeaders()).thenReturn(sessionHeader);
+
+            AwsErrorDetails awsErrorDetails =
+                    AwsErrorDetails.builder()
+                            .errorCode("")
+                            .sdkHttpResponse(
+                                    SdkHttpResponse.builder()
+                                            .statusCode(HttpStatusCode.INTERNAL_SERVER_ERROR)
+                                            .build())
+                            .errorMessage("AWS DynamoDbException Occurred")
+                            .build();
+            when(mockPersonIdentityService.getPersonIdentity(
+                            UUID.fromString(sessionHeader.get(HEADER_SESSION_ID))))
+                    .thenThrow(
+                            AwsServiceException.builder()
+                                    .statusCode(500)
+                                    .awsErrorDetails(awsErrorDetails)
+                                    .build());
+
+            setupEventProbeErrorBehaviour();
+            APIGatewayProxyResponseEvent response =
+                    questionHandler.handleRequest(input, mock(Context.class));
+
+            assertEquals("{ \"error\":\"AWS Server error occurred.\" }", response.getBody());
+            assertEquals(HttpStatusCode.INTERNAL_SERVER_ERROR, response.getStatusCode());
+
+            verify(mockPersonIdentityService)
+                    .getPersonIdentity(UUID.fromString(sessionHeader.get(HEADER_SESSION_ID)));
+            verify(mockEventProbe).counterMetric(GET_QUESTION, 0d);
+        }
+
+        @Test
+        void shouldReturn500ErrorWhenExperianServiceIsDown() throws IOException {
+
+            APIGatewayProxyRequestEvent input = mock(APIGatewayProxyRequestEvent.class);
+            Map<String, String> sessionHeader =
+                    Map.of(HEADER_SESSION_ID, UUID.randomUUID().toString());
+
+            KBVItem kbvItemMock = mock(KBVItem.class);
+            PersonIdentity personIdentityMock = mock(PersonIdentity.class);
+            QuestionState questionStateMock = mock(QuestionState.class);
+
+            when(input.getHeaders()).thenReturn(sessionHeader);
+            when(mockKBVStorageService.getKBVItem(
+                            UUID.fromString(sessionHeader.get(HEADER_SESSION_ID))))
+                    .thenReturn(kbvItemMock);
+            when(mockPersonIdentityService.getPersonIdentity(
+                            UUID.fromString(sessionHeader.get(HEADER_SESSION_ID))))
+                    .thenReturn(personIdentityMock);
+
+            when(mockObjectMapper.readValue(kbvItemMock.getQuestionState(), QuestionState.class))
+                    .thenReturn(questionStateMock);
+
+            doThrow(RuntimeException.class)
+                    .when(spyKBVService)
+                    .getQuestions(any(QuestionRequest.class));
+
+            setupEventProbeErrorBehaviour();
+            APIGatewayProxyResponseEvent response =
+                    questionHandler.handleRequest(input, mock(Context.class));
+
+            assertEquals(HttpStatusCode.INTERNAL_SERVER_ERROR, response.getStatusCode());
+            verify(mockEventProbe).counterMetric(GET_QUESTION, 0d);
+        }
+
+        @Test
+        void shouldReturn204WhenAGivenSessionHasReceivedFinalResponseFromExperian()
+                throws IOException {
+
+            APIGatewayProxyRequestEvent input = mock(APIGatewayProxyRequestEvent.class);
+            Map<String, String> sessionHeader =
+                    Map.of(HEADER_SESSION_ID, UUID.randomUUID().toString());
+
+            Context contextMock = mock(Context.class);
+            KBVItem kbvItemMock = mock(KBVItem.class);
+            QuestionState questionStateMock = mock(QuestionState.class);
+
+            when(input.getHeaders()).thenReturn(sessionHeader);
+            when(mockKBVStorageService.getKBVItem(
+                            UUID.fromString(sessionHeader.get(HEADER_SESSION_ID))))
+                    .thenReturn(kbvItemMock);
+
+            when(mockObjectMapper.readValue(kbvItemMock.getQuestionState(), QuestionState.class))
+                    .thenReturn(questionStateMock);
+
+            when(mockEventProbe.counterMetric(GET_QUESTION)).thenReturn(mockEventProbe);
+            when(kbvItemMock.getStatus()).thenReturn("status-code");
+            APIGatewayProxyResponseEvent response =
+                    questionHandler.handleRequest(input, contextMock);
+
+            assertEquals(HttpStatusCode.NO_CONTENT, response.getStatusCode());
+            assertNull(response.getBody());
+            verify(mockEventProbe).counterMetric(GET_QUESTION);
+        }
+    }
+
+    @Nested
+    class ProcessQuestionRequest {
+        void shouldReturnNoQuestionsWhenQuestionStateAndKbvItemEmptyObjects()
+                throws SqsException, IOException {
+            var question =
+                    questionHandler.processQuestionRequest(new QuestionState(), new KBVItem());
+
+            assertNull(question);
+        }
+
+        @Test
+        void shouldReturnThrowErrorWhenQuestionStateIsNull() {
+            var kbvItem = new KBVItem();
+            NullPointerException expectedException =
+                    assertThrows(
+                            NullPointerException.class,
+                            () -> questionHandler.processQuestionRequest(null, kbvItem));
+
+            assertEquals("questionState cannot be null", expectedException.getMessage());
+        }
+
+        @Test
+        void shouldReturnThrowErrorWhenKbvItemIsNull() {
+            var questionState = new QuestionState();
+            NullPointerException expectedException =
+                    assertThrows(
+                            NullPointerException.class,
+                            () -> questionHandler.processQuestionRequest(questionState, null));
+
+            assertEquals("kbvItem cannot be null", expectedException.getMessage());
+        }
+
+        @Test
+        void shouldReturnNextQuestionFromDbStoreWhenThereIsAnUnansweredQuestionInStorage()
+                throws IOException, SqsException {
+            QuestionState questionState = new QuestionState();
+            Questions questions = new Questions();
+
+            Question answeredQuestion = getQuestionOne();
+            QuestionAnswer questionAnswer = new QuestionAnswer();
+            questionAnswer.setQuestionId(answeredQuestion.getQuestionID());
+            questionAnswer.setAnswer("OVER £35,000 UP TO £60,000");
+
+            Question unAnsweredQuestion = getQuestionTwo();
+            questions.getQuestion().addAll(List.of(answeredQuestion, unAnsweredQuestion));
+
+            questionState.setQAPairs(questions);
+            questionState.setAnswer(questionAnswer);
+
+            Question nextQuestion =
+                    questionHandler.processQuestionRequest(questionState, mock(KBVItem.class));
+
+            assertEquals(nextQuestion.getQuestionID(), unAnsweredQuestion.getQuestionID());
+        }
+
+        @Test
+        void shouldReturnNextQuestionFromExperianWhenFirstCalled()
+                throws IOException, SqsException {
+            QuestionState questionState = new QuestionState();
+            PersonIdentity personIdentity = new PersonIdentity();
+
+            KBVItem kbvItem = new KBVItem();
+            UUID sessionId = UUID.randomUUID();
+            kbvItem.setSessionId(sessionId);
+
+            when(mockPersonIdentityService.getPersonIdentity(sessionId)).thenReturn(personIdentity);
+            doReturn(getExperianQuestionResponse()).when(spyKBVService).getQuestions(any());
+            Question nextQuestionFromExperian =
+                    questionHandler.processQuestionRequest(questionState, kbvItem);
+
+            assertEquals(
+                    nextQuestionFromExperian.getQuestionID(),
+                    getExperianQuestionResponse()
+                            .getQuestions()
+                            .getQuestion()
+                            .get(0)
+                            .getQuestionID());
+        }
+
+        @Test
+        void shouldReturnNextQuestionFromExperianWhenBothAnQuestionsInStorageAreAnswered()
+                throws IOException, SqsException {
+            QuestionState questionState = new QuestionState();
+            Questions questions = new Questions();
+
+            Question firstAnsweredQuestion = getQuestionOne();
+            QuestionAnswer questionAnswerOne = new QuestionAnswer();
+            questionAnswerOne.setQuestionId(firstAnsweredQuestion.getQuestionID());
+            questionAnswerOne.setAnswer("OVER £35,000 UP TO £60,000");
+
+            Question secondAnsweredQuestion = getQuestionTwo();
+            QuestionAnswer questionAnswerTwo = new QuestionAnswer();
+            questionAnswerTwo.setQuestionId(secondAnsweredQuestion.getQuestionID());
+            questionAnswerTwo.setAnswer("Blue");
+
+            questions.getQuestion().addAll(List.of(firstAnsweredQuestion, secondAnsweredQuestion));
+
+            questionState.setQAPairs(questions);
+            questionState.setAnswer(questionAnswerOne);
+            questionState.setAnswer(questionAnswerTwo);
+
+            KBVItem kbvItem =
+                    getADummyKBVItemThatRepresentAnItemInStorage(
+                            new ObjectMapper().writeValueAsString(questionState));
+            when(mockObjectMapper.readValue(kbvItem.getQuestionState(), QuestionState.class))
+                    .thenReturn(questionState);
+            doReturn(getExperianQuestionResponse()).when(spyKBVService).submitAnswers(any());
+            Question nextQuestionFromExperian =
+                    questionHandler.processQuestionRequest(questionState, kbvItem);
+
+            assertEquals(
+                    nextQuestionFromExperian.getQuestionID(),
+                    getExperianQuestionResponse()
+                            .getQuestions()
+                            .getQuestion()
+                            .get(0)
+                            .getQuestionID());
+        }
+    }
+
+    private KBVItem getADummyKBVItemThatRepresentAnItemInStorage(String questionStateString) {
         KBVItem kbvItem = new KBVItem();
-        kbvItem.setSessionId(UUID.fromString(sessionHeader.get(HEADER_SESSION_ID)));
-        PersonIdentity personIdentityMock = mock(PersonIdentity.class);
-        QuestionState questionStateMock = mock(QuestionState.class);
-
-        when(input.getHeaders()).thenReturn(sessionHeader);
-        when(mockPersonIdentityService.getPersonIdentity(kbvItem.getSessionId()))
-                .thenReturn(personIdentityMock);
-
-        when(mockKBVStorageService.getKBVItem(
-                        UUID.fromString(sessionHeader.get(HEADER_SESSION_ID))))
-                .thenReturn(kbvItem);
-
-        when(mockObjectMapper.readValue(kbvItem.getQuestionState(), QuestionState.class))
-                .thenReturn(questionStateMock);
-
-        QuestionsResponse questionsResponseMock = mock(QuestionsResponse.class);
-
-        when(questionsResponseMock.hasQuestions()).thenReturn(true);
-        String state = "question-state";
-        when(mockObjectMapper.writeValueAsString(questionStateMock)).thenReturn(state);
-        com.experian.uk.schema.experian.identityiq.services.webservice.Control controlMock =
-                mock(Control.class);
-        when(questionsResponseMock.getControl()).thenReturn(controlMock);
-        String authRefNo = "auth-ref-no";
-        when(controlMock.getAuthRefNo()).thenReturn(authRefNo);
-        String ipvSessionId = "ipv-session-id";
-        when(controlMock.getURN()).thenReturn(ipvSessionId);
-
-        Question expectedQuestion = mock(Question.class);
-        when(mockKBVGateway.getQuestions(any())).thenReturn(questionsResponseMock);
-        when(questionStateMock.getNextQuestion()) // we have to do this to get it to work
-                .thenReturn(Optional.empty()) // otherwise the second overrides the first
-                .thenReturn(Optional.ofNullable(expectedQuestion));
-
-        when(mockObjectMapper.writeValueAsString(expectedQuestion))
-                .thenReturn(TestData.EXPECTED_QUESTION);
-
-        APIGatewayProxyResponseEvent response = questionHandler.handleRequest(input, contextMock);
-
-        assertEquals(HttpStatusCode.OK, response.getStatusCode());
-        assertEquals(TestData.EXPECTED_QUESTION, response.getBody());
-        verify(mockAuditService).sendAuditEvent(AuditEventType.REQUEST_SENT);
-        verify(mockEventProbe).counterMetric(GET_QUESTION);
-    }
-
-    @Test
-    void shouldReturn200OkWhenCalledAgainAndReturnNextUnAnsweredQuestionFromStorage()
-            throws IOException {
-        APIGatewayProxyRequestEvent input = mock(APIGatewayProxyRequestEvent.class);
-        Map<String, String> sessionHeader = Map.of(HEADER_SESSION_ID, UUID.randomUUID().toString());
-
-        Context contextMock = mock(Context.class);
-        KBVItem kbvItem = new KBVItem();
-        kbvItem.setSessionId(UUID.fromString(sessionHeader.get(HEADER_SESSION_ID)));
-
-        QuestionState questionStateMock = mock(QuestionState.class);
-
-        when(input.getHeaders()).thenReturn(sessionHeader);
-        when(mockKBVStorageService.getKBVItem(
-                        UUID.fromString(sessionHeader.get(HEADER_SESSION_ID))))
-                .thenReturn(kbvItem);
-        when(mockObjectMapper.readValue(kbvItem.getQuestionState(), QuestionState.class))
-                .thenReturn(questionStateMock);
-
-        Question question2 = mock(Question.class);
-
-        when(questionStateMock.getNextQuestion()).thenReturn(Optional.ofNullable(question2));
-
-        when(mockObjectMapper.writeValueAsString(question2)).thenReturn(TestData.EXPECTED_QUESTION);
-
-        APIGatewayProxyResponseEvent response = questionHandler.handleRequest(input, contextMock);
-
-        assertEquals(HttpStatusCode.OK, response.getStatusCode());
-        assertEquals(TestData.EXPECTED_QUESTION, response.getBody());
-        verify(mockEventProbe).counterMetric(GET_QUESTION);
-    }
-
-    @Test
-    void shouldReturn400ErrorWhenNoFurtherQuestions() throws IOException {
-        Context contextMock = mock(Context.class);
-        APIGatewayProxyRequestEvent input = mock(APIGatewayProxyRequestEvent.class);
-        Map<String, String> sessionHeader = Map.of(HEADER_SESSION_ID, UUID.randomUUID().toString());
-
-        PersonIdentity personIdentity = new PersonIdentity();
-        KBVItem kbvItem = new KBVItem();
-        kbvItem.setSessionId(UUID.fromString(sessionHeader.get(HEADER_SESSION_ID)));
-        QuestionState questionStateMock = mock(QuestionState.class);
-
-        when(input.getHeaders()).thenReturn(sessionHeader);
-        when(mockKBVStorageService.getKBVItem(
-                        UUID.fromString(sessionHeader.get(HEADER_SESSION_ID))))
-                .thenReturn(kbvItem);
-        when(mockPersonIdentityService.getPersonIdentity(kbvItem.getSessionId()))
-                .thenReturn(personIdentity);
-
-        when(mockObjectMapper.readValue(kbvItem.getQuestionState(), QuestionState.class))
-                .thenReturn(questionStateMock);
-
-        APIGatewayProxyResponseEvent response = questionHandler.handleRequest(input, contextMock);
-
-        verify(mockKBVStorageService)
-                .getKBVItem(UUID.fromString(sessionHeader.get(HEADER_SESSION_ID)));
-        verify(mockObjectMapper).readValue(kbvItem.getQuestionState(), QuestionState.class);
-        verify(mockEventProbe).counterMetric(GET_QUESTION);
-
-        assertEquals(HttpStatusCode.BAD_REQUEST, response.getStatusCode());
-    }
-
-    @Test
-    void shouldReturn400ErrorWhenNoSessionIdProvided() {
-        APIGatewayProxyRequestEvent input = mock(APIGatewayProxyRequestEvent.class);
-        setupEventProbeErrorBehaviour();
-
-        APIGatewayProxyResponseEvent response =
-                questionHandler.handleRequest(input, mock(Context.class));
-
-        String expectedMessage = "java.lang.NullPointerException";
-        assertTrue(response.getBody().contains(expectedMessage));
-        assertEquals(HttpStatusCode.BAD_REQUEST, response.getStatusCode());
-        verify(mockEventProbe).counterMetric(GET_QUESTION, 0d);
-    }
-
-    @Test
-    void shouldReturn500ErrorWhenAWSDynamoDBServiceDown() {
-        APIGatewayProxyRequestEvent input = mock(APIGatewayProxyRequestEvent.class);
-        Map<String, String> sessionHeader = Map.of(HEADER_SESSION_ID, UUID.randomUUID().toString());
-
-        when(input.getHeaders()).thenReturn(sessionHeader);
-        doThrow(InternalServerErrorException.class)
-                .when(mockKBVStorageService)
-                .getKBVItem(UUID.fromString(sessionHeader.get(HEADER_SESSION_ID)));
-
-        setupEventProbeErrorBehaviour();
-        APIGatewayProxyResponseEvent response =
-                questionHandler.handleRequest(input, mock(Context.class));
-
-        assertEquals("{ \"error\":\"AWS Server error occurred.\" }", response.getBody());
-        assertEquals(HttpStatusCode.INTERNAL_SERVER_ERROR, response.getStatusCode());
-        verify(mockEventProbe).counterMetric(GET_QUESTION, 0d);
-    }
-
-    @Test
-    void shouldReturn500ErrorWhenPersonIdentityCannotBeRetrievedDueToAnAwsError() {
-        APIGatewayProxyRequestEvent input = mock(APIGatewayProxyRequestEvent.class);
-        Map<String, String> sessionHeader = Map.of(HEADER_SESSION_ID, UUID.randomUUID().toString());
-
-        when(input.getHeaders()).thenReturn(sessionHeader);
-
-        AwsErrorDetails awsErrorDetails =
-                AwsErrorDetails.builder()
-                        .errorCode("")
-                        .sdkHttpResponse(
-                                SdkHttpResponse.builder()
-                                        .statusCode(HttpStatusCode.INTERNAL_SERVER_ERROR)
-                                        .build())
-                        .errorMessage("AWS DynamoDbException Occurred")
-                        .build();
-        when(mockPersonIdentityService.getPersonIdentity(
-                        UUID.fromString(sessionHeader.get(HEADER_SESSION_ID))))
-                .thenThrow(
-                        AwsServiceException.builder()
-                                .statusCode(500)
-                                .awsErrorDetails(awsErrorDetails)
-                                .build());
-
-        setupEventProbeErrorBehaviour();
-        APIGatewayProxyResponseEvent response =
-                questionHandler.handleRequest(input, mock(Context.class));
-
-        assertEquals("{ \"error\":\"AWS Server error occurred.\" }", response.getBody());
-        assertEquals(HttpStatusCode.INTERNAL_SERVER_ERROR, response.getStatusCode());
-
-        verify(mockPersonIdentityService)
-                .getPersonIdentity(UUID.fromString(sessionHeader.get(HEADER_SESSION_ID)));
-        verify(mockEventProbe).counterMetric(GET_QUESTION, 0d);
-    }
-
-    @Test
-    void shouldReturn500ErrorWhenExperianServiceIsDown() throws IOException {
-
-        APIGatewayProxyRequestEvent input = mock(APIGatewayProxyRequestEvent.class);
-        Map<String, String> sessionHeader = Map.of(HEADER_SESSION_ID, UUID.randomUUID().toString());
-
-        KBVItem kbvItemMock = mock(KBVItem.class);
-        PersonIdentity personIdentityMock = mock(PersonIdentity.class);
-        QuestionState questionStateMock = mock(QuestionState.class);
-
-        when(input.getHeaders()).thenReturn(sessionHeader);
-        when(mockKBVStorageService.getKBVItem(
-                        UUID.fromString(sessionHeader.get(HEADER_SESSION_ID))))
-                .thenReturn(kbvItemMock);
-        when(mockPersonIdentityService.getPersonIdentity(
-                        UUID.fromString(sessionHeader.get(HEADER_SESSION_ID))))
-                .thenReturn(personIdentityMock);
-
-        when(mockObjectMapper.readValue(kbvItemMock.getQuestionState(), QuestionState.class))
-                .thenReturn(questionStateMock);
-
-        doThrow(RuntimeException.class)
-                .when(spyKBVService)
-                .getQuestions(any(QuestionRequest.class));
-
-        setupEventProbeErrorBehaviour();
-        APIGatewayProxyResponseEvent response =
-                questionHandler.handleRequest(input, mock(Context.class));
-
-        assertEquals(HttpStatusCode.INTERNAL_SERVER_ERROR, response.getStatusCode());
-        verify(mockEventProbe).counterMetric(GET_QUESTION, 0d);
-    }
-
-    @Test
-    void shouldReturn204WhenAGivenSessionHasReceivedFinalResponseFromExperian() throws IOException {
-
-        APIGatewayProxyRequestEvent input = mock(APIGatewayProxyRequestEvent.class);
-        Map<String, String> sessionHeader = Map.of(HEADER_SESSION_ID, UUID.randomUUID().toString());
-
-        Context contextMock = mock(Context.class);
-        KBVItem SessionItemMock = mock(KBVItem.class);
-        QuestionState questionStateMock = mock(QuestionState.class);
-
-        when(input.getHeaders()).thenReturn(sessionHeader);
-        when(mockKBVStorageService.getKBVItem(
-                        UUID.fromString(sessionHeader.get(HEADER_SESSION_ID))))
-                .thenReturn(SessionItemMock);
-
-        when(mockObjectMapper.readValue(SessionItemMock.getQuestionState(), QuestionState.class))
-                .thenReturn(questionStateMock);
-
-        when(SessionItemMock.getStatus()).thenReturn("status-code");
-        APIGatewayProxyResponseEvent response = questionHandler.handleRequest(input, contextMock);
-
-        assertEquals(HttpStatusCode.NO_CONTENT, response.getStatusCode());
-        assertNull(response.getBody());
-        verify(mockEventProbe).counterMetric(GET_QUESTION);
+        kbvItem.setQuestionState(questionStateString);
+        kbvItem.setExpiryDate(9090L); // this implies kbvItem already exists
+        return kbvItem;
     }
 
     private void setupEventProbeErrorBehaviour() {
         when(mockEventProbe.counterMetric(anyString(), anyDouble())).thenReturn(mockEventProbe);
         when(mockEventProbe.log(any(Level.class), any(Exception.class))).thenReturn(mockEventProbe);
+    }
+
+    private Question getQuestionOne() {
+        Question question = new Question();
+        question.setQuestionID("Q00015");
+        question.setText("What is the outstanding balance ");
+        question.setTooltip("outstanding balance tooltip");
+        AnswerFormat answerFormat = new AnswerFormat();
+        answerFormat.setIdentifier("A00004");
+        answerFormat.setIdentifier("G");
+        answerFormat
+                .getAnswerList()
+                .addAll(
+                        List.of(
+                                "UP TO £10,000",
+                                "OVER £35,000 UP TO £60,000",
+                                "OVER £60,000 UP TO £85,000",
+                                "NONE OF THE ABOVE / DOES NOT APPLY"));
+        question.setAnswerFormat(answerFormat);
+        return question;
+    }
+
+    private Question getQuestionTwo() {
+        Question question = new Question();
+        question.setQuestionID("Q00040");
+        question.setText("What your favorite color");
+        question.setTooltip("favorite color tooltip");
+
+        AnswerFormat answerFormat = new AnswerFormat();
+        answerFormat.setIdentifier("A00005");
+        answerFormat.setIdentifier("G");
+        answerFormat
+                .getAnswerList()
+                .addAll(List.of("Blue", "Red", "Green", "NONE OF THE ABOVE / DOES NOT APPLY"));
+        question.setAnswerFormat(answerFormat);
+        return question;
+    }
+
+    private Question newQuestion() {
+        Question question = new Question();
+        question.setQuestionID("Q00057");
+        question.setText("What your top five movies");
+        question.setTooltip("top five movies tooltip");
+
+        AnswerFormat answerFormat = new AnswerFormat();
+        answerFormat.setIdentifier("A00006");
+        answerFormat.setIdentifier("G");
+        answerFormat
+                .getAnswerList()
+                .addAll(
+                        List.of(
+                                "The God father",
+                                "The Shawshank Redemption",
+                                "The Green Mile",
+                                "Schindler's List",
+                                "Casablanca",
+                                "NONE OF THE ABOVE / DOES NOT APPLY"));
+        question.setAnswerFormat(answerFormat);
+        return question;
+    }
+
+    private QuestionsResponse getExperianQuestionResponse() {
+        return getExperianQuestionResponse(Collections.singletonList(new Question()));
+    }
+
+    private QuestionsResponse getExperianQuestionResponse(List<Question> questionList) {
+        QuestionsResponse questionsResponse = new QuestionsResponse();
+        Questions questions = new Questions();
+        Control control = new Control();
+        control.setAuthRefNo("authrefno");
+        control.setURN("urn");
+        questions.getQuestion().addAll(questionList);
+        questionsResponse.setQuestions(questions);
+        questionsResponse.setControl(control);
+
+        return questionsResponse;
     }
 }

--- a/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/TestData.java
+++ b/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/TestData.java
@@ -1,7 +1,0 @@
-package uk.gov.di.ipv.cri.kbv.api.handler;
-
-public final class TestData {
-
-    public static final String EXPECTED_QUESTION =
-            "{\"questionID\":\"Q00015\",\"text\":\"What is the first James Bond movie?\",\"tooltip\":\"It was released in the 1960s.\",\"answerHeldFlag\":null,\"answerFormat\":{\"identifier\":\"A00004\",\"fieldType\":\"G \",\"answerList\":[\"Movie 1\",\"Movie 2\",\"Movie 3\"]}}";
-}


### PR DESCRIPTION

## Proposed changes

Make `processQuestionRequest` return a Question instead of being a void method

### What changed

`processQuestionRequest` now returns a Question if available or null

### Why did it change

`processQuestionRequest` also mutated the state of the response object and returned void

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-508](https://govukverify.atlassian.net/browse/KBV-508)

## Checklists

 tests that explicitly covers the `processQuestionRequest` method