### PR TITLE
KBV-543: expose the abandon kbv api endpoint

### DIFF
--- a/infrastructure/lambda/api.yaml
+++ b/infrastructure/lambda/api.yaml
@@ -253,6 +253,32 @@ paths:
         contentHandling: "CONVERT_TO_TEXT"
         type: "aws_proxy"
 
+  /abandon:
+    post:
+      parameters:
+        - $ref: "#/components/parameters/SessionHeader"
+      responses:
+        "200":
+          description: "200 response"
+        "400":
+          description: "400 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: "500 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+      x-amazon-apigateway-request-validator: "Validate Param only"
+      x-amazon-apigateway-integration:
+        type: "aws_proxy"
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${KBVAbandonFunction.Arn}/invocations"
+        passthroughBehavior: "when_no_match"
 components:
   parameters:
     SessionHeader:
@@ -436,4 +462,8 @@ x-amazon-apigateway-request-validators:
   Validate both:
     validateRequestBody: true
     validateRequestParameters: true
+  Validate Param only:
+    validateRequestParameters: true
+    validateRequestBody: false
+
 

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -411,6 +411,35 @@ Resources:
               Resource:
                 - !ImportValue AuditEventQueueEncryptionKeyArn
 
+  KBVAbandonFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../../lambdas/abandon/build/distributions/abandon.zip
+      Handler: uk.gov.di.ipv.cri.kbv.api.handler.AbandonKbvHandler::handleRequest
+      Environment:
+        Variables:
+          POWERTOOLS_SERVICE_NAME: di-ipv-cri-kbv-api-abandon
+      Policies:
+        - DynamoDBReadPolicy:
+            TableName:
+              Ref: SessionTable
+        - DynamoDBWritePolicy:
+            TableName:
+              Ref: SessionTable
+        - Statement:
+            - Effect: Allow
+              Action:
+                - ssm:GetParameter
+              Resource:
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/SessionTableName"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/SessionTtl"
+        - Statement:
+            - Effect: Allow
+              Action:
+                - ssm:GetParametersByPath
+              Resource:
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/clients/*"
+
   IssueCredentialFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -445,7 +474,6 @@ Resources:
               - kms:GenerateDataKey
             Resource:
               - !ImportValue AuditEventQueueEncryptionKeyArn
-
   KBVTable:
     Type: "AWS::DynamoDB::Table"
     Properties:
@@ -733,6 +761,13 @@ Resources:
     Properties:
       Action: lambda:InvokeFunction
       FunctionName: !GetAtt KBVAnswerFunction.Arn
+      Principal: apigateway.amazonaws.com
+
+  KBVAbandonFunctionPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !GetAtt KBVAbandonFunction.Arn
       Principal: apigateway.amazonaws.com
 
   IssueCredentialFunctionPermission:

--- a/lambdas/abandon/build.gradle
+++ b/lambdas/abandon/build.gradle
@@ -1,0 +1,32 @@
+plugins {
+	id "java"
+	id 'io.freefair.aspectj.post-compile-weaving' version '6.3.0'
+}
+
+dependencies {
+	implementation project(":lib"),
+			configurations.aws,
+			configurations.lambda
+
+	aspect configurations.powertools
+	testImplementation configurations.tests
+	testRuntimeOnly configurations.test_runtime
+}
+
+test {
+	useJUnitPlatform()
+}
+
+task buildZip(type: Zip) {
+	from compileJava
+	from processResources
+	into('lib') {
+		from configurations.runtimeClasspath
+	}
+}
+
+build.finalizedBy(buildZip)
+
+test {
+	useJUnitPlatform()
+}

--- a/lambdas/abandon/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/AbandonKbvHandler.java
+++ b/lambdas/abandon/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/AbandonKbvHandler.java
@@ -1,0 +1,23 @@
+package uk.gov.di.ipv.cri.kbv.api.handler;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import software.amazon.awssdk.http.HttpStatusCode;
+
+import java.util.Map;
+
+public class AbandonKbvHandler
+        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent input, Context context) {
+        APIGatewayProxyResponseEvent response = new APIGatewayProxyResponseEvent();
+
+        response.withHeaders(Map.of("Content-Type", "application/json"));
+        response.withStatusCode(HttpStatusCode.OK);
+        return response;
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,8 @@ project(':authorization').projectDir = new File('./common-lambdas/authorization'
 include "lib"
 
 // CRI specific lambdas
-include "question", "answer", "issuecredential"
+include "question", "answer", "issuecredential", "abandon"
 project(':question').projectDir = new File('./lambdas/question')
 project(':answer').projectDir = new File('./lambdas/answer')
 project(':issuecredential').projectDir = new File('./lambdas/issuecredential')
+project(':abandon').projectDir = new File('./lambdas/abandon')


### PR DESCRIPTION
This is an **initial PR** to add a /abandon endpoint to API Gateway, subsequent PR would set the status of KBV journey to "Abandon" in the KBV table

## Proposed changes

Expose an the /abandon endpoint, this will be called be KBV frontend client, when user decides to discontinue with KBV

### What changed

A new lambda was added, that returns a 200 Ok response

### Why did it change

This enables the user to discontinue the KBV journey see https://govukverify.atlassian.net/browse/KBV-543


- [KBV-543](https://govukverify.atlassian.net/browse/KBV-543)



### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks