### PR TITLE
KBV-566 Add private api gateway

### DIFF
--- a/infrastructure/lambda/private-api.yaml
+++ b/infrastructure/lambda/private-api.yaml
@@ -1,0 +1,439 @@
+openapi: "3.0.1"
+info:
+  title: "Knowledge Base Verification Credential Issuer Api"
+  version: "1.0"
+
+paths:
+
+  /session:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Authorization"
+        required: true
+      responses:
+        "400":
+          description: "400 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: "500 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "201":
+          description: "201 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Session"
+      x-amazon-apigateway-request-validator: "Validate both"
+      x-amazon-apigateway-integration:
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SessionFunction.Arn}/invocations
+        responses:
+          default:
+            statusCode: "200"
+        passthroughBehavior: "when_no_match"
+        contentHandling: "CONVERT_TO_TEXT"
+        type: "aws_proxy"
+
+  /authorization:
+    get:
+      parameters:
+        - $ref: "#/components/parameters/SessionHeader"
+      responses:
+        "200":
+          description: "200 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthorizationResponse"
+        "400":
+          description: "400 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: "500 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+      x-amazon-apigateway-request-validator: "Validate both"
+      x-amazon-apigateway-integration:
+        type: "aws_proxy"
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AuthorizationFunction.Arn}/invocations"
+        passthroughBehavior: "when_no_match"
+
+  /token:
+    post:
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              required:
+                - "grant_type"
+                - "code"
+                - "client_assertion_type"
+                - "client_assertion"
+                - "redirect_uri"
+              properties:
+                grant_type:
+                  type: "string"
+                  pattern: "authorization_code"
+                  example: "authorization_code"
+                code:
+                  type: "string"
+                  minLength: 1
+                client_assertion_type:
+                  type: "string"
+                  pattern: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+                  example: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+                client_assertion:
+                  type: "string"
+                  pattern: "[a-zA-Z0-9_=]+\\.[a-zA-Z0-9_=]+\\.[a-zA-Z0-9_\\-\\+\\/=]+"
+                  example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0dCIsImlhdCI6MTUxNjIzOTAyMn0.SbcN-ywpLObhMbbaMCtW1Un8LYhQzHsEth9LvTk4oQQ"
+                redirect_uri:
+                  type: "string"
+                  format: "uri"
+                  example: "https://di-ipv-core-stub.london.cloudapps.digital/callback"
+      responses:
+        "201":
+          description: "201 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TokenResponse"
+        "400":
+          description: "400 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: "500 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+      x-amazon-apigateway-request-validator: "Validate both"
+      x-amazon-apigateway-integration:
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AccessTokenFunction.Arn}/invocations
+        responses:
+          default:
+            statusCode: "200"
+        passthroughBehavior: "when_no_match"
+        contentHandling: "CONVERT_TO_TEXT"
+        type: "aws_proxy"
+
+  /question:
+    get:
+      parameters:
+        - $ref: "#/components/parameters/SessionHeader"
+      responses:
+        "200":
+          description: "200 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Question"
+        "204":
+          description: "204 response"
+        "400":
+          description: "400 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: "500 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+      x-amazon-apigateway-request-validator: "Validate both"
+      x-amazon-apigateway-integration:
+        type: "aws_proxy"
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${KBVQuestionFunction.Arn}/invocations"
+        passthroughBehavior: "when_no_match"
+
+  /answer:
+    post:
+      parameters:
+        - $ref: "#/components/parameters/SessionHeader"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Answer"
+        required: true
+      responses:
+        "200":
+          description: "200 response"
+        "400":
+          description: "400 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: "500 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+      x-amazon-apigateway-request-validator: "Validate both"
+      x-amazon-apigateway-integration:
+        type: "aws_proxy"
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${KBVAnswerFunction.Arn}/invocations"
+        passthroughBehavior: "when_no_match"
+
+  /credential/issue:
+    summary: Resource for the KBV API
+    description: >-
+      This API is expected to be called by the IPV core backend directly as the
+      final part of the OpenId/Oauth Flow
+    parameters:
+      - name: Authorization
+        in: header
+        required: true
+        description: 'A valid access_token (e.g.: authorization: Bearer access-token-value).'
+        schema:
+          type: string
+    post:
+      summary: GET request using a valid access token
+      responses:
+        '200':
+          description: 200 Ok
+          content:
+            application/jwt:
+              schema:
+                type: string
+                format: application/jwt
+                pattern: ^([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_\-\+\/=]+)$
+                example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+        '400':
+          description: 400 Bad Response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '500':
+          description: 500 Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+      x-amazon-apigateway-request-validator: "Validate both"
+      x-amazon-apigateway-integration:
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IssueCredentialFunction.Arn}/invocations
+        responses:
+          default:
+            statusCode: "200"
+        passthroughBehavior: "when_no_match"
+        contentHandling: "CONVERT_TO_TEXT"
+        type: "aws_proxy"
+
+components:
+  parameters:
+    SessionHeader:
+      name: session-id
+      in: header
+      description: A UUID generated by the KBV API to act as a primary key for the KBVTable in DynamoDB
+      required: true
+      schema:
+        type: string
+  schemas:
+    TokenResponse:
+      title: AccessToken
+      required:
+        - "access_token"
+        - "expires_in"
+      type: "object"
+      properties:
+        access_token:
+          type: string
+          description: The Access Token for the given token request
+        token_type:
+          type: string
+          description: The Token Type issued
+          example: Bearer
+        expires_in:
+          type: string
+          description: The expiry time, in seconds
+          example: '3600'
+        refresh_token:
+          type: string
+          description: The refresh token is optional, not currently applicable
+    Authorization:
+      required:
+        - "client_id"
+        - "request"
+      type: "object"
+      properties:
+        client_id:
+          type: "string"
+          minLength: 1
+          example: "ipv-core-stub"
+        request:
+          type: "string"
+    AuthorizationResponse:
+      required:
+        - "redirect_uri"
+        - "code"
+        - "state"
+      type: "object"
+      properties:
+        code:
+          type: "string"
+          example: "981bb74c-3b5e-462e-ba3a-abf868e5da68"
+        state:
+          type: "string"
+          example: "state"
+          minLength: 1
+        redirect_uri:
+          type: "string"
+          format: "uri"
+          example: "https://di-ipv-core-stub.london.cloudapps.digital/callback"
+    Error:
+      title: "Error Schema"
+      type: "object"
+      properties:
+        message:
+          type: "string"
+    Session:
+      required:
+        - "session_id"
+      type: "object"
+      properties:
+        session_id:
+          type: "string"
+    Question:
+      type: "object"
+      properties:
+        questionID:
+          type: "string"
+        text:
+          type: "string"
+        tooltip:
+          type: "string"
+        answerHeldFlag:
+          type: "string"
+        answerFormat:
+          type: "object"
+          $ref: "#/components/schemas/AnswerFormat"
+    AnswerFormat:
+      type: "object"
+      properties:
+        identifier:
+          type: "string"
+        fieldType:
+          type: "string"
+        answerList:
+          type: array
+          items:
+            type: "string"
+    Answer:
+      type: "object"
+      properties:
+        questionId:
+          description: The unique identifier for the question
+          maxLength: 6
+          type: "string"
+        answer:
+          description: Answer provided by the user
+          maxLength: 50
+          type: "string"
+    Address:
+      title: "Address Update Request"
+      type: "array"
+      items:
+        $ref: "#/components/schemas/CanonicalAddress"
+    CanonicalAddress:
+      title: "Canonical Address"
+      type: "object"
+      properties:
+        uprn:
+          type: "number"
+          example: 1234567890
+          description: "Unique Property Reference Number"
+        organisationName:
+          type: "string"
+          example: "Some Organisation"
+        departmentName:
+          type: "string"
+          example: "Some Department"
+        subBuildingName:
+          type: "string"
+          example: "Some Sub Building"
+        buildingNumber:
+          type: "string"
+          example: "1"
+        dependentStreetName:
+          type: "string"
+          example: "Some Street"
+        doubleDependentAddressLocality:
+          type: "string"
+          example: "Some Town"
+        dependentAddressLocality:
+          type: "string"
+          example: "Some Area"
+        buildingName:
+          type: "string"
+          example: "Some Building"
+        streetName:
+          type: "string"
+          example: "Some Street"
+        addressLocality:
+          type: "string"
+          example: "Some Town"
+        postalCode:
+          type: "string"
+          example: "SW1A 1AA"
+        addressCountry:
+          type: "string"
+          example: "GBR"
+          description: "ISO 3-Letter Country Code"
+        validFrom:
+          description: "Date in ISO 8601 format"
+          type: "string"
+          example: "2020-01-01"
+        validUntil:
+          description: "Date in ISO 8601 format"
+          type: "string"
+          example: "2020-01-01"
+
+
+#  securitySchemes:
+#    api_key:
+#      type: "apiKey"
+#      name: "x-api-key"
+#      in: "header"
+#
+#security:
+#  - api_key: []
+
+x-amazon-apigateway-request-validators:
+  Validate both:
+    validateRequestBody: true
+    validateRequestParameters: true
+

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -69,7 +69,17 @@ Globals:
         POWERTOOLS_LOG_LEVEL: INFO
         POWERTOOLS_METRICS_NAMESPACE: di-ipv-cri-kbv-api
         SQS_AUDIT_EVENT_PREFIX: IPV_KBV_CRI
+
 Mappings:
+
+  VPCEndpointIdMapping:
+    Environment:
+      dev: vpce-082cab7c78139eb54
+      build: vpce-0e2d78b216ac3b3a2
+      staging: vpce-08fe2404d765e9fff
+      integration: vpce-02e2c1e10f0be4fdd
+      production: vpce-02c08839b3c7c33eb
+
   SessionTtlMapping:
     Environment:
       dev: "172800" # 2 days

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -221,10 +221,75 @@ Resources:
       EndpointConfiguration:
         Type: REGIONAL
 
+  PrivateKBVApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      MethodSettings:
+        - LoggingLevel: INFO
+          ResourcePath: '/*'
+          HttpMethod: '*'
+          # Disable data trace in production to avoid logging customer sensitive information
+          DataTraceEnabled: true
+          MetricsEnabled: true
+          ThrottlingRateLimit: 5
+          ThrottlingBurstLimit: 10
+      AccessLogSetting:
+        DestinationArn: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${ApiAccessLogGroup}'
+        Format: >-
+          {
+          "requestId":"$context.requestId",
+          "ip":"$context.identity.sourceIp",
+          "requestTime":"$context.requestTime",
+          "httpMethod":"$context.httpMethod",
+          "path":"$context.path",
+          "routeKey":"$context.routeKey",
+          "status":"$context.status",
+          "protocol":"$context.protocol",
+          "responseLatency":"$context.responseLatency",
+          "responseLength":"$context.responseLength"
+          }
+      TracingEnabled: true
+      Name: !Sub "kbv-cri-private-${AWS::StackName}"
+      StageName: !Ref Environment
+      DefinitionBody:
+        openapi: "3.0.1" # workaround to get `sam validate` to work
+        paths: # workaround to get `sam validate` to work
+          /never-created:
+            options: { } # workaround to get `sam validate` to work
+        Fn::Transform:
+          Name: AWS::Include
+          Parameters:
+            Location: './private-api.yaml'
+      OpenApiVersion: 3.0.1
+      EndpointConfiguration:
+        Type: PRIVATE
+      Auth:
+        ResourcePolicy:
+          CustomStatements:
+            - Action: 'execute-api:Invoke'
+              Effect: Allow
+              Principal: '*'
+              Resource:
+                - 'execute-api:/*'
+            - Action: 'execute-api:Invoke'
+              Effect: Deny
+              Principal: '*'
+              Resource:
+                - 'execute-api:/*'
+              Condition:
+                StringNotEquals:
+                  'aws:SourceVpce': !FindInMap [ VPCEndpointIdMapping, Environment, !Ref 'Environment' ]
+
   ApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/apigateway/AccessLog-${KBVApi}/${Environment}
+      RetentionInDays: 365
+
+  PrivateApiAccessLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/apigateway/AccessLog-${PrivateKBVApi}/${Environment}
       RetentionInDays: 365
 
   SessionFunction:
@@ -766,38 +831,26 @@ Resources:
 
 Outputs:
 
-  SessionApiUrl:
-    Description: "URL for the KBV API /session resource"
-    Value: !Sub "https://${KBVApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/session"
-    Export:
-      Name: !Sub ${AWS::StackName}-SessionApiUrl
-
-  TokenApiUrl:
-    Description: "URL for the KBV API /token resource"
-    Value: !Sub "https://${KBVApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/token"
-    Export:
-      Name: !Sub ${AWS::StackName}-TokenApiUrl
-
-  CredentialIssueApiUrl:
-    Description: "URL for the KBV API /credential/issue resource"
-    Value: !Sub "https://${KBVApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/credential/issue"
-    Export:
-      Name: !Sub ${AWS::StackName}-CredentialIssueApiUrl
-
-  JWKSetApiUrl:
-    Description: "URL for the KBV API /.well-known/jwks.json resource"
-    Value: !Sub "https://${KBVApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/.well-known/jwks.json"
-    Export:
-      Name: !Sub ${AWS::StackName}-JWKSetApiUrl
-
   KBVApiBaseUrl:
     Description: "Base url of the KBV CRI API"
     Value: !Sub "https://${KBVApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/"
     Export:
       Name: !Sub ${AWS::StackName}-KBVApiBaseUrl
-      
+
   KBVApiGatewayId:
     Description: "API GatewayID of the KBV CRI API"
     Value: !Sub "${KBVApi}"
     Export:
-      Name: !Sub ${AWS::StackName}-KBVApiGatewayId 
+      Name: !Sub ${AWS::StackName}-KBVApiGatewayId
+
+  PrivateKBVApiBaseUrl:
+    Description: "Base url of the private KBV CRI API"
+    Value: !Sub "https://${PrivateKBVApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/"
+    Export:
+      Name: !Sub ${AWS::StackName}-PrivateKBVApiBaseUrl
+
+  PrivateKBVApiGatewayId:
+    Description: "API GatewayID of the private KBV CRI API"
+    Value: !Sub "${PrivateKBVApi}"
+    Export:
+      Name: !Sub ${AWS::StackName}-PrivateKBVApiGatewayId

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -283,13 +283,13 @@ Resources:
   ApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/apigateway/AccessLog-${KBVApi}/${Environment}
+      LogGroupName: !Sub /aws/apigateway/AccessLog-public-${KBVApi}/${Environment}
       RetentionInDays: 365
 
   PrivateApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/apigateway/AccessLog-${PrivateKBVApi}/${Environment}
+      LogGroupName: !Sub /aws/apigateway/AccessLog-private-${PrivateKBVApi}/${Environment}
       RetentionInDays: 365
 
   SessionFunction:

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -192,7 +192,19 @@ Resources:
           ThrottlingBurstLimit: 10
       AccessLogSetting:
         DestinationArn: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${ApiAccessLogGroup}'
-        Format: '{ "requestId":"$context.requestId", "ip": "$context.identity.sourceIp", "caller":"$context.identity.caller", "user":"$context.identity.user","requestTime":"$context.requestTime", "httpMethod":"$context.httpMethod","resourcePath":"$context.resourcePath", "status":"$context.status","protocol":"$context.protocol", "responseLength":"$context.responseLength" }'
+        Format: >-
+          {
+          "requestId":"$context.requestId",
+          "ip":"$context.identity.sourceIp",
+          "requestTime":"$context.requestTime",
+          "httpMethod":"$context.httpMethod",
+          "path":"$context.path",
+          "routeKey":"$context.routeKey",
+          "status":"$context.status",
+          "protocol":"$context.protocol",
+          "responseLatency":"$context.responseLatency",
+          "responseLength":"$context.responseLength"
+          }
       TracingEnabled: true
       Name: !Sub "kbv-cri-${AWS::StackName}"
       StageName: !Ref Environment


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Add a private AWS API Gateway accessible from the VPC endpoint id only. It configures access to the same API endpoints as the public API for now.

This will allow to check whether our Fargate frontend can use the private API, which we can configure in the frontend repo.
If so, we can make further API changes to bucket our endpoints into public and private APIs.
