### PR TITLE
KBV-543: abandon kbv api update kbv item to abandoned

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -507,25 +507,18 @@ Resources:
         Variables:
           POWERTOOLS_SERVICE_NAME: di-ipv-cri-kbv-api-abandon
       Policies:
+        - AWSLambdaBasicExecutionRole
+        - AWSXrayWriteOnlyAccess
         - DynamoDBReadPolicy:
-            TableName:
-              Ref: SessionTable
+            TableName: !Ref KBVTable
         - DynamoDBWritePolicy:
-            TableName:
-              Ref: SessionTable
+            TableName: !Ref KBVTable
         - Statement:
-            - Effect: Allow
-              Action:
-                - ssm:GetParameter
-              Resource:
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/SessionTableName"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/SessionTtl"
-        - Statement:
-            - Effect: Allow
-              Action:
-                - ssm:GetParametersByPath
-              Resource:
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/clients/*"
+          - Effect: Allow
+            Action:
+              - ssm:GetParameter
+            Resource:
+              - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/KBVTableName"
 
   IssueCredentialFunction:
     Type: AWS::Serverless::Function

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -513,12 +513,18 @@ Resources:
             TableName: !Ref KBVTable
         - DynamoDBWritePolicy:
             TableName: !Ref KBVTable
+        - DynamoDBReadPolicy:
+            TableName: !Ref SessionTable
+        - DynamoDBWritePolicy:
+            TableName: !Ref SessionTable
         - Statement:
           - Effect: Allow
             Action:
               - ssm:GetParameter
             Resource:
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/KBVTableName"
+              - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/SessionTableName"
+
 
   IssueCredentialFunction:
     Type: AWS::Serverless::Function

--- a/lambdas/abandon/build.gradle
+++ b/lambdas/abandon/build.gradle
@@ -4,7 +4,8 @@ plugins {
 }
 
 dependencies {
-	implementation project(":lib"),
+	implementation project(":common-lib"),
+			project(":lib"),
 			configurations.aws,
 			configurations.lambda
 

--- a/lambdas/abandon/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/AbandonKbvHandler.java
+++ b/lambdas/abandon/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/AbandonKbvHandler.java
@@ -18,10 +18,9 @@ import static org.apache.logging.log4j.Level.ERROR;
 
 public class AbandonKbvHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
-    public static final String ABANDON_STATUS = "Abandoned";
-
-    public static final String HEADER_SESSION_ID = "session-id";
-    public static final String ABANDON_KBV = "abandon_kbv";
+    private static final String ABANDON_STATUS = "Abandoned";
+    private static final String HEADER_SESSION_ID = "session-id";
+    private static final String ABANDON_KBV = "abandon_kbv";
     private final EventProbe eventProbe;
     private final KBVStorageService kbvStorageService;
     private final SessionService sessionService;
@@ -36,9 +35,10 @@ public class AbandonKbvHandler
     }
 
     public AbandonKbvHandler() {
-        this.eventProbe = new EventProbe();
-        this.kbvStorageService = new KBVStorageService(new ConfigurationService());
-        this.sessionService = new SessionService();
+        this(
+                new EventProbe(),
+                new KBVStorageService(new ConfigurationService()),
+                new SessionService());
     }
 
     @Override
@@ -54,11 +54,10 @@ public class AbandonKbvHandler
             kbvStorageService.update(kbvItem);
 
             var sessionItem = sessionService.getSession(sessionId.toString());
-            sessionItem.setAuthorizationCode(UUID.randomUUID().toString());
             sessionService.createAuthorizationCode(sessionItem);
 
             response.withStatusCode(HttpStatusCode.OK);
-            eventProbe.counterMetric(ABANDON_KBV, 0d);
+            eventProbe.counterMetric(ABANDON_KBV);
             return response;
         } catch (NullPointerException npe) {
             response.withStatusCode(HttpStatusCode.BAD_REQUEST);

--- a/lambdas/abandon/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/AbandonKbvHandler.java
+++ b/lambdas/abandon/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/AbandonKbvHandler.java
@@ -5,19 +5,52 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import software.amazon.awssdk.http.HttpStatusCode;
+import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
+import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
+import uk.gov.di.ipv.cri.kbv.api.service.KBVStorageService;
 
 import java.util.Map;
+import java.util.UUID;
+
+import static org.apache.logging.log4j.Level.ERROR;
 
 public class AbandonKbvHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+    public static final String ABANDON_STATUS = "Abandoned";
+
+    public static final String HEADER_SESSION_ID = "session-id";
+    public static final String ABANDON_KBV = "abandon_kbv";
+    private final EventProbe eventProbe;
+    private final KBVStorageService kbvStorageService;
+
+    public AbandonKbvHandler(EventProbe eventProbe, KBVStorageService kbvStorageService) {
+        this.eventProbe = eventProbe;
+        this.kbvStorageService = kbvStorageService;
+    }
+
+    public AbandonKbvHandler() {
+        this.eventProbe = new EventProbe();
+        this.kbvStorageService = new KBVStorageService(new ConfigurationService());
+    }
 
     @Override
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
         APIGatewayProxyResponseEvent response = new APIGatewayProxyResponseEvent();
-
         response.withHeaders(Map.of("Content-Type", "application/json"));
-        response.withStatusCode(HttpStatusCode.OK);
+        try {
+            UUID sessionId = UUID.fromString(input.getHeaders().get(HEADER_SESSION_ID));
+            KBVItem kbvItem = kbvStorageService.getKBVItem(sessionId);
+            kbvItem.setStatus(ABANDON_STATUS);
+            kbvStorageService.update(kbvItem);
+            response.withStatusCode(HttpStatusCode.OK);
+            eventProbe.counterMetric(ABANDON_KBV, 0d);
+            return response;
+        } catch (NullPointerException npe) {
+            response.withStatusCode(HttpStatusCode.BAD_REQUEST);
+            eventProbe.log(ERROR, npe).counterMetric(ABANDON_KBV, 0d);
+        }
         return response;
     }
 }

--- a/lambdas/abandon/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/AbandonKbvHandlerTest.java
+++ b/lambdas/abandon/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/AbandonKbvHandlerTest.java
@@ -8,7 +8,12 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.http.HttpStatusCode;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
+import uk.gov.di.ipv.cri.common.library.service.SessionService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
 import uk.gov.di.ipv.cri.kbv.api.service.KBVStorageService;
@@ -31,30 +36,38 @@ import static uk.gov.di.ipv.cri.kbv.api.handler.AbandonKbvHandler.HEADER_SESSION
 @ExtendWith(MockitoExtension.class)
 class AbandonKbvHandlerTest {
     @Mock private EventProbe mockEventProbe;
-    @InjectMocks private AbandonKbvHandler abandonKbvHandler;
     @Mock private APIGatewayProxyRequestEvent input;
     @Mock private KBVStorageService mockKbvStorageService;
+    @Mock private SessionService mockSessionService;
+    @InjectMocks private AbandonKbvHandler abandonKbvHandler;
 
     @Test
     void shouldReturn200OkWhenItReceivesAValidRequest() {
         Map<String, String> sessionHeader = Map.of(HEADER_SESSION_ID, UUID.randomUUID().toString());
-
         when(input.getHeaders()).thenReturn(sessionHeader);
+
         KBVItem kbvItem = new KBVItem();
         when(mockKbvStorageService.getKBVItem(
                         UUID.fromString(sessionHeader.get(HEADER_SESSION_ID))))
                 .thenReturn(kbvItem);
+        SessionItem mockSessionItem = mock(SessionItem.class);
+        when(mockSessionService.getSession(sessionHeader.get(HEADER_SESSION_ID)))
+                .thenReturn(mockSessionItem);
         var result = abandonKbvHandler.handleRequest(input, mock(Context.class));
 
         assertEquals(HttpStatusCode.OK, result.getStatusCode());
-        assertEquals(kbvItem.getStatus(), ABANDON_STATUS);
+        assertEquals(ABANDON_STATUS, kbvItem.getStatus());
+
+        verify(mockKbvStorageService)
+                .getKBVItem(UUID.fromString(sessionHeader.get(HEADER_SESSION_ID)));
         verify(mockKbvStorageService).update(kbvItem);
+        verify(mockSessionItem).setAuthorizationCode(any());
+        verify(mockSessionService).createAuthorizationCode(mockSessionItem);
         verify(mockEventProbe).counterMetric(ABANDON_KBV, 0d);
     }
 
     @Test
     void shouldReturnErrorBadRequestWhenItReceivesARequestThatDoesNotContainASessionId() {
-        Map<String, String> sessionHeader = Map.of(HEADER_SESSION_ID, UUID.randomUUID().toString());
         when(mockEventProbe.log(any(ERROR.getClass()), any(NullPointerException.class)))
                 .thenReturn(mockEventProbe);
         when(mockEventProbe.counterMetric(ABANDON_KBV, 0d)).thenReturn(mockEventProbe);
@@ -67,21 +80,85 @@ class AbandonKbvHandlerTest {
     }
 
     @Test
-    void shouldReturn400BadRequestWhenKbvItemStatusIsNotSetToAbandon() {
+    void shouldReturn500InternalServerErrorWhenKbvItemCannotBeRetrievedDueToAWSError() {
         ArgumentCaptor<String> abandonStatusCapture = ArgumentCaptor.forClass(String.class);
+        Map<String, String> sessionHeader = Map.of(HEADER_SESSION_ID, UUID.randomUUID().toString());
+        when(input.getHeaders()).thenReturn(sessionHeader);
 
-        KBVItem kbvItem = mock(KBVItem.class);
+        var kbvItem = mock(KBVItem.class);
 
-        when(mockEventProbe.log(any(ERROR.getClass()), any(NullPointerException.class)))
+        AwsErrorDetails awsErrorDetails =
+                AwsErrorDetails.builder()
+                        .errorCode("")
+                        .sdkHttpResponse(
+                                SdkHttpResponse.builder()
+                                        .statusCode(HttpStatusCode.INTERNAL_SERVER_ERROR)
+                                        .build())
+                        .errorMessage("AWS Server error occurred.")
+                        .build();
+        when(mockKbvStorageService.getKBVItem(
+                        UUID.fromString(input.getHeaders().get(HEADER_SESSION_ID))))
+                .thenThrow(
+                        AwsServiceException.builder()
+                                .statusCode(500)
+                                .awsErrorDetails(awsErrorDetails)
+                                .build());
+
+        when(mockEventProbe.log(any(ERROR.getClass()), any(AwsServiceException.class)))
                 .thenReturn(mockEventProbe);
         when(mockEventProbe.counterMetric(ABANDON_KBV, 0d)).thenReturn(mockEventProbe);
 
         verify(kbvItem, never()).setStatus(abandonStatusCapture.capture());
 
-        var result = abandonKbvHandler.handleRequest(input, mock(Context.class));
-        assertNotEquals(kbvItem.getStatus(), ABANDON_STATUS);
-        assertEquals(HttpStatusCode.BAD_REQUEST, result.getStatusCode());
-        verify(mockEventProbe).log(any(ERROR.getClass()), any(NullPointerException.class));
+        var response = abandonKbvHandler.handleRequest(input, mock(Context.class));
+
+        assertEquals(HttpStatusCode.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertNotEquals(ABANDON_STATUS, kbvItem.getStatus());
+        verify(mockKbvStorageService)
+                .getKBVItem(UUID.fromString(input.getHeaders().get(HEADER_SESSION_ID)));
+        verify(mockKbvStorageService, never()).update(kbvItem);
+        verify(mockEventProbe).log(any(ERROR.getClass()), any(AwsServiceException.class));
+        verify(mockEventProbe).counterMetric(ABANDON_KBV, 0d);
+    }
+
+    @Test
+    void shouldReturn500InternalServerErrorWhenSessionItemCannotBeRetrievedDueToAWSSError() {
+        Map<String, String> sessionHeader = Map.of(HEADER_SESSION_ID, UUID.randomUUID().toString());
+        when(input.getHeaders()).thenReturn(sessionHeader);
+        var authorizationCode = UUID.randomUUID();
+        var kbvItem = new KBVItem();
+        var mockSessionItem = mock(SessionItem.class);
+        when(mockKbvStorageService.getKBVItem(
+                        UUID.fromString(sessionHeader.get(HEADER_SESSION_ID))))
+                .thenReturn(kbvItem);
+        AwsErrorDetails awsErrorDetails =
+                AwsErrorDetails.builder()
+                        .errorCode("")
+                        .sdkHttpResponse(
+                                SdkHttpResponse.builder()
+                                        .statusCode(HttpStatusCode.INTERNAL_SERVER_ERROR)
+                                        .build())
+                        .errorMessage("AWS Server error occurred.")
+                        .build();
+
+        when(mockSessionService.getSession(sessionHeader.get(HEADER_SESSION_ID)))
+                .thenThrow(
+                        AwsServiceException.builder()
+                                .statusCode(500)
+                                .awsErrorDetails(awsErrorDetails)
+                                .build());
+        when(mockEventProbe.log(any(ERROR.getClass()), any(AwsServiceException.class)))
+                .thenReturn(mockEventProbe);
+        when(mockEventProbe.counterMetric(ABANDON_KBV, 0d)).thenReturn(mockEventProbe);
+
+        var response = abandonKbvHandler.handleRequest(input, mock(Context.class));
+
+        assertEquals(HttpStatusCode.INTERNAL_SERVER_ERROR, response.getStatusCode());
+
+        verify(mockSessionItem, never()).setAuthorizationCode(String.valueOf(authorizationCode));
+        verify(mockSessionService).getSession(sessionHeader.get(HEADER_SESSION_ID));
+        verify(mockSessionService, never()).createAuthorizationCode(mockSessionItem);
+        verify(mockEventProbe).log(any(ERROR.getClass()), any(AwsServiceException.class));
         verify(mockEventProbe).counterMetric(ABANDON_KBV, 0d);
     }
 }

--- a/lambdas/abandon/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/AbandonKbvHandlerTest.java
+++ b/lambdas/abandon/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/AbandonKbvHandlerTest.java
@@ -1,0 +1,87 @@
+package uk.gov.di.ipv.cri.kbv.api.handler;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.http.HttpStatusCode;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
+import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
+import uk.gov.di.ipv.cri.kbv.api.service.KBVStorageService;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.apache.logging.log4j.Level.ERROR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.cri.kbv.api.handler.AbandonKbvHandler.ABANDON_KBV;
+import static uk.gov.di.ipv.cri.kbv.api.handler.AbandonKbvHandler.ABANDON_STATUS;
+import static uk.gov.di.ipv.cri.kbv.api.handler.AbandonKbvHandler.HEADER_SESSION_ID;
+
+@ExtendWith(MockitoExtension.class)
+class AbandonKbvHandlerTest {
+    @Mock private EventProbe mockEventProbe;
+    @InjectMocks private AbandonKbvHandler abandonKbvHandler;
+    @Mock private APIGatewayProxyRequestEvent input;
+    @Mock private KBVStorageService mockKbvStorageService;
+
+    @Test
+    void shouldReturn200OkWhenItReceivesAValidRequest() {
+        Map<String, String> sessionHeader = Map.of(HEADER_SESSION_ID, UUID.randomUUID().toString());
+
+        when(input.getHeaders()).thenReturn(sessionHeader);
+        KBVItem kbvItem = new KBVItem();
+        when(mockKbvStorageService.getKBVItem(
+                        UUID.fromString(sessionHeader.get(HEADER_SESSION_ID))))
+                .thenReturn(kbvItem);
+        var result = abandonKbvHandler.handleRequest(input, mock(Context.class));
+
+        assertEquals(HttpStatusCode.OK, result.getStatusCode());
+        assertEquals(kbvItem.getStatus(), ABANDON_STATUS);
+        verify(mockKbvStorageService).update(kbvItem);
+        verify(mockEventProbe).counterMetric(ABANDON_KBV, 0d);
+    }
+
+    @Test
+    void shouldReturnErrorBadRequestWhenItReceivesARequestThatDoesNotContainASessionId() {
+        Map<String, String> sessionHeader = Map.of(HEADER_SESSION_ID, UUID.randomUUID().toString());
+        when(mockEventProbe.log(any(ERROR.getClass()), any(NullPointerException.class)))
+                .thenReturn(mockEventProbe);
+        when(mockEventProbe.counterMetric(ABANDON_KBV, 0d)).thenReturn(mockEventProbe);
+
+        var result = abandonKbvHandler.handleRequest(input, mock(Context.class));
+
+        assertEquals(HttpStatusCode.BAD_REQUEST, result.getStatusCode());
+        verify(mockEventProbe).log(any(ERROR.getClass()), any(NullPointerException.class));
+        verify(mockEventProbe).counterMetric(ABANDON_KBV, 0d);
+    }
+
+    @Test
+    void shouldReturn400BadRequestWhenKbvItemStatusIsNotSetToAbandon() {
+        ArgumentCaptor<String> abandonStatusCapture = ArgumentCaptor.forClass(String.class);
+
+        KBVItem kbvItem = mock(KBVItem.class);
+
+        when(mockEventProbe.log(any(ERROR.getClass()), any(NullPointerException.class)))
+                .thenReturn(mockEventProbe);
+        when(mockEventProbe.counterMetric(ABANDON_KBV, 0d)).thenReturn(mockEventProbe);
+
+        verify(kbvItem, never()).setStatus(abandonStatusCapture.capture());
+
+        var result = abandonKbvHandler.handleRequest(input, mock(Context.class));
+        assertNotEquals(kbvItem.getStatus(), ABANDON_STATUS);
+        assertEquals(HttpStatusCode.BAD_REQUEST, result.getStatusCode());
+        verify(mockEventProbe).log(any(ERROR.getClass()), any(NullPointerException.class));
+        verify(mockEventProbe).counterMetric(ABANDON_KBV, 0d);
+    }
+}


### PR DESCRIPTION
This is the 2nd PR to the Abandon KBV which updates the KBVItem status to Abandoned, and creates the authorization code
see: https://github.com/alphagov/di-ipv-cri-kbv-api/pull/75

## Proposed changes

This PR updates the KBVItem status to `Abandoned` and creates the AuthorizationCode for the session linked to the KBV


### What changed

/abandon endpoint with a post request using the session-id, that identifies the KBV journey, function then sets the status of KBV to `Abandoned` and sets the session authorization code

### Why did it change

So as to ensure that users have the option to discontinue with KBV if they wish to do so

- [KBV-543](https://govukverify.atlassian.net/browse/KBV-543)

