### PR TITLE
BAU: Required field validation on /answer endpoint

### DIFF
--- a/infrastructure/lambda/api.yaml
+++ b/infrastructure/lambda/api.yaml
@@ -379,6 +379,9 @@ components:
           items:
             type: "string"
     Answer:
+      required:
+        - "questionId"
+        - "answer"
       type: "object"
       properties:
         questionId:


### PR DESCRIPTION
This PR addresses Required field validation on API Gateway endpoint
for answer endpoint

## Proposed changes

if you have the following payload body to the /answer endpoint
```
{
   "questionId": "Q00036"
}
```
Currently, API gateway allows the request

Valid request should be:
```
{
   "questionId": "Q00036"
   "answer": "The answer"
}
```

