### PR TITLE
KBV-533 Fix the loggroup ref for public and private apigws

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -178,7 +178,7 @@ Mappings:
       production: "https://di-ipv-cri-kbv-front.london.cloudapps.digital"
 
 Resources:
-  KBVApi:
+  PublicKBVApi:
     Type: AWS::Serverless::Api
     Properties:
       MethodSettings:
@@ -191,7 +191,7 @@ Resources:
           ThrottlingRateLimit: 5
           ThrottlingBurstLimit: 10
       AccessLogSetting:
-        DestinationArn: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${ApiAccessLogGroup}'
+        DestinationArn: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${PublicApiAccessLogGroup}'
         Format: >-
           {
           "requestId":"$context.requestId",
@@ -234,7 +234,7 @@ Resources:
           ThrottlingRateLimit: 5
           ThrottlingBurstLimit: 10
       AccessLogSetting:
-        DestinationArn: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${ApiAccessLogGroup}'
+        DestinationArn: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${PrivateApiAccessLogGroup}'
         Format: >-
           {
           "requestId":"$context.requestId",
@@ -280,16 +280,16 @@ Resources:
                 StringNotEquals:
                   'aws:SourceVpce': !FindInMap [ VPCEndpointIdMapping, Environment, !Ref 'Environment' ]
 
-  ApiAccessLogGroup:
+  PublicApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/apigateway/AccessLog-public-${KBVApi}/${Environment}
+      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${PublicKBVApi}-public-AccessLogs
       RetentionInDays: 365
 
   PrivateApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/apigateway/AccessLog-private-${PrivateKBVApi}/${Environment}
+      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${PrivateKBVApi}-private-AccessLogs
       RetentionInDays: 365
 
   SessionFunction:
@@ -631,13 +631,28 @@ Resources:
         AttributeName: expiryDate
         Enabled: true
 
-  ApiUsagePlan:
+  PublicApiUsagePlan:
     Type: AWS::ApiGateway::UsagePlan
     DependsOn:
-      - KBVApiStage
+      - PublicKBVApiStage
     Properties:
       ApiStages:
-        - ApiId: !Ref KBVApi
+        - ApiId: !Ref PublicKBVApi
+          Stage: !Ref Environment
+      Quota:
+        Limit: 500000
+        Period: DAY
+      Throttle:
+        BurstLimit: 100 # requests the API can handle concurrently
+        RateLimit: 50 # allowed requests per second
+
+  PrivateApiUsagePlan:
+    Type: AWS::ApiGateway::UsagePlan
+    DependsOn:
+      - PrivateKBVApiStage
+    Properties:
+      ApiStages:
+        - ApiId: !Ref PrivateKBVApi
           Stage: !Ref Environment
       Quota:
         Limit: 500000
@@ -651,14 +666,14 @@ Resources:
     Properties:
       KeyId: !ImportValue core-infrastructure-ApiKey1
       KeyType: API_KEY
-      UsagePlanId: !Ref ApiUsagePlan
+      UsagePlanId: !Ref PublicApiUsagePlan
 
   LinkUsagePlanApiKey2:
     Type: AWS::ApiGateway::UsagePlanKey
     Properties:
       KeyId: !ImportValue core-infrastructure-ApiKey2
       KeyType: API_KEY
-      UsagePlanId: !Ref ApiUsagePlan
+      UsagePlanId: !Ref PublicApiUsagePlan
 
   ParameterSessionTableName:
     Type: AWS::SSM::Parameter
@@ -867,13 +882,13 @@ Outputs:
 
   KBVApiBaseUrl:
     Description: "Base url of the KBV CRI API"
-    Value: !Sub "https://${KBVApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/"
+    Value: !Sub "https://${PublicKBVApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/"
     Export:
       Name: !Sub ${AWS::StackName}-KBVApiBaseUrl
 
   KBVApiGatewayId:
     Description: "API GatewayID of the KBV CRI API"
-    Value: !Sub "${KBVApi}"
+    Value: !Sub "${PublicKBVApi}"
     Export:
       Name: !Sub ${AWS::StackName}-KBVApiGatewayId
 

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -894,6 +894,18 @@ Outputs:
     Export:
       Name: !Sub ${AWS::StackName}-KBVApiGatewayId
 
+  PublicKBVApiBaseUrl:
+    Description: "Base url of the public KBV CRI API"
+    Value: !Sub "https://${PublicKBVApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/"
+    Export:
+      Name: !Sub ${AWS::StackName}-PublicKBVApiBaseUrl
+
+  PublicKBVApiGatewayId:
+    Description: "API GatewayID of the public KBV CRI API"
+    Value: !Sub "${PublicKBVApi}"
+    Export:
+      Name: !Sub ${AWS::StackName}-PublicKBVApiGatewayId
+
   PrivateKBVApiBaseUrl:
     Description: "Base url of the private KBV CRI API"
     Value: !Sub "https://${PrivateKBVApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/"

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -181,6 +181,7 @@ Resources:
   PublicKBVApi:
     Type: AWS::Serverless::Api
     Properties:
+      Description: Public KBV CRI API
       MethodSettings:
         - LoggingLevel: INFO
           ResourcePath: '/*'
@@ -224,6 +225,7 @@ Resources:
   PrivateKBVApi:
     Type: AWS::Serverless::Api
     Properties:
+      Description: Private KBV CRI API
       MethodSettings:
         - LoggingLevel: INFO
           ResourcePath: '/*'

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -192,7 +192,7 @@ Resources:
           ThrottlingRateLimit: 5
           ThrottlingBurstLimit: 10
       AccessLogSetting:
-        DestinationArn: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${PublicApiAccessLogGroup}'
+        DestinationArn: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${PublicKBVApiAccessLogGroup}'
         Format: >-
           {
           "requestId":"$context.requestId",
@@ -236,7 +236,7 @@ Resources:
           ThrottlingRateLimit: 5
           ThrottlingBurstLimit: 10
       AccessLogSetting:
-        DestinationArn: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${PrivateApiAccessLogGroup}'
+        DestinationArn: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${PrivateKBVApiAccessLogGroup}'
         Format: >-
           {
           "requestId":"$context.requestId",
@@ -282,13 +282,13 @@ Resources:
                 StringNotEquals:
                   'aws:SourceVpce': !FindInMap [ VPCEndpointIdMapping, Environment, !Ref 'Environment' ]
 
-  PublicApiAccessLogGroup:
+  PublicKBVApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${PublicKBVApi}-public-AccessLogs
       RetentionInDays: 365
 
-  PrivateApiAccessLogGroup:
+  PrivateKBVApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${PrivateKBVApi}-private-AccessLogs


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Fixed the log groups for the public and private APIGWs.

Also:
* renamed the public `KBVApi` to `PublicKBVApi` to make it clearer that it is public
* renamed APIGW access log loggroup names to make them easier to find
* output and export the `PublicKBVApi` id and base url


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-533](https://govukverify.atlassian.net/browse/KBV-533)
