### PR TITLE
Add error to logging

### DIFF
--- a/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/exception/QuestionNotFoundException.java
+++ b/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/exception/QuestionNotFoundException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.ipv.cri.kbv.api.exception;
+
+public class QuestionNotFoundException extends RuntimeException {
+    public QuestionNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
+++ b/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
@@ -23,6 +23,7 @@ import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswerRequest;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionRequest;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionState;
+import uk.gov.di.ipv.cri.kbv.api.exception.QuestionNotFoundException;
 import uk.gov.di.ipv.cri.kbv.api.gateway.KBVGatewayFactory;
 import uk.gov.di.ipv.cri.kbv.api.gateway.QuestionsResponse;
 import uk.gov.di.ipv.cri.kbv.api.service.KBVService;
@@ -105,9 +106,8 @@ public class QuestionHandler
 
             Question question = processQuestionRequest(questionState, kbvItem);
             response.withBody(objectMapper.writeValueAsString(question));
-            response.withStatusCode(question != null ? OK : BAD_REQUEST);
-
-            eventProbe.counterMetric(GET_QUESTION, question != null ? 1 : 0);
+            response.withStatusCode(OK);
+            eventProbe.counterMetric(GET_QUESTION);
         } catch (JsonProcessingException jsonProcessingException) {
             eventProbe.log(ERROR, jsonProcessingException).counterMetric(GET_QUESTION, 0d);
             response.withStatusCode(HttpStatusCode.INTERNAL_SERVER_ERROR);
@@ -117,6 +117,10 @@ public class QuestionHandler
             eventProbe.log(ERROR, npe).counterMetric(GET_QUESTION, 0d);
             response.withStatusCode(BAD_REQUEST);
             response.withBody("{ " + ERROR_KEY + ":\"" + npe + "\" }");
+        } catch (QuestionNotFoundException qe) {
+            eventProbe.log(ERROR, qe).counterMetric(GET_QUESTION, 0d);
+            response.withStatusCode(HttpStatusCode.INTERNAL_SERVER_ERROR);
+            response.withBody("{ " + ERROR_KEY + ":\"" + qe.getMessage() + "\" }");
         } catch (IOException e) {
             eventProbe.log(ERROR, e).counterMetric(GET_QUESTION, 0d);
             response.withStatusCode(HttpStatusCode.INTERNAL_SERVER_ERROR);
@@ -141,7 +145,7 @@ public class QuestionHandler
             saveQuestionStateToKbvItem(kbvItem, questionState, questionsResponse);
             return question;
         }
-        return null;
+        throw new QuestionNotFoundException("Question not Found");
     }
 
     private Question getQuestionFromDbStore(QuestionState questionState) {

--- a/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
+++ b/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
@@ -107,7 +107,7 @@ public class QuestionHandler
             response.withBody(objectMapper.writeValueAsString(question));
             response.withStatusCode(question != null ? OK : BAD_REQUEST);
 
-            eventProbe.counterMetric(GET_QUESTION);
+            eventProbe.counterMetric(GET_QUESTION, question != null ? 1 : 0);
         } catch (JsonProcessingException jsonProcessingException) {
             eventProbe.log(ERROR, jsonProcessingException).counterMetric(GET_QUESTION, 0d);
             response.withStatusCode(HttpStatusCode.INTERNAL_SERVER_ERROR);

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/StartAuthnAttemptRequestMapper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/StartAuthnAttemptRequestMapper.java
@@ -10,8 +10,6 @@ import com.experian.uk.schema.experian.identityiq.services.webservice.Error;
 import com.experian.uk.schema.experian.identityiq.services.webservice.LocationDetails;
 import com.experian.uk.schema.experian.identityiq.services.webservice.LocationDetailsUKLocation;
 import com.experian.uk.schema.experian.identityiq.services.webservice.Parameters;
-import com.experian.uk.schema.experian.identityiq.services.webservice.Question;
-import com.experian.uk.schema.experian.identityiq.services.webservice.Questions;
 import com.experian.uk.schema.experian.identityiq.services.webservice.Residency;
 import com.experian.uk.schema.experian.identityiq.services.webservice.Results;
 import com.experian.uk.schema.experian.identityiq.services.webservice.SAARequest;
@@ -62,7 +60,7 @@ public class StartAuthnAttemptRequestMapper {
         String transIds = "";
         String errorCode = "";
         String errorMessage = "";
-            String confirmationCode = "";
+        String confirmationCode = "";
 
         if (control != null) {
             urn = control.getURN();

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/StartAuthnAttemptRequestMapper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/StartAuthnAttemptRequestMapper.java
@@ -6,9 +6,12 @@ import com.experian.uk.schema.experian.identityiq.services.webservice.ApplicantN
 import com.experian.uk.schema.experian.identityiq.services.webservice.ApplicationData;
 import com.experian.uk.schema.experian.identityiq.services.webservice.ArrayOfString;
 import com.experian.uk.schema.experian.identityiq.services.webservice.Control;
+import com.experian.uk.schema.experian.identityiq.services.webservice.Error;
 import com.experian.uk.schema.experian.identityiq.services.webservice.LocationDetails;
 import com.experian.uk.schema.experian.identityiq.services.webservice.LocationDetailsUKLocation;
 import com.experian.uk.schema.experian.identityiq.services.webservice.Parameters;
+import com.experian.uk.schema.experian.identityiq.services.webservice.Question;
+import com.experian.uk.schema.experian.identityiq.services.webservice.Questions;
 import com.experian.uk.schema.experian.identityiq.services.webservice.Residency;
 import com.experian.uk.schema.experian.identityiq.services.webservice.Results;
 import com.experian.uk.schema.experian.identityiq.services.webservice.SAARequest;
@@ -43,19 +46,23 @@ public class StartAuthnAttemptRequestMapper {
         questionsResponse.setQuestions(sAAResponse2.getQuestions());
         Control control = sAAResponse2.getControl();
         questionsResponse.setControl(control);
-        questionsResponse.setError(sAAResponse2.getError());
+        Error error = sAAResponse2.getError();
+        questionsResponse.setError(error);
         Results results = sAAResponse2.getResults();
-        logQuestionResponse(control, results);
+        logQuestionResponse(control, results, error);
         questionsResponse.setResults(results);
         return questionsResponse;
     }
 
-    private void logQuestionResponse(Control control, Results results) {
+    private void logQuestionResponse(Control control, Results results, Error error) {
         String urn = "";
         String authRefNo = "";
         String outcome = "";
         String authenticationResult = "";
         String transIds = "";
+        String errorCode = "";
+        String errorMessage = "";
+            String confirmationCode = "";
 
         if (control != null) {
             urn = control.getURN();
@@ -63,9 +70,7 @@ public class StartAuthnAttemptRequestMapper {
         }
         if (results != null) {
             outcome = results.getOutcome();
-            LOGGER.info("question response outcome: " + outcome);
             authenticationResult = results.getAuthenticationResult();
-            LOGGER.info("question response authenticationResult: " + authenticationResult);
             ArrayOfString nextTransId = results.getNextTransId();
             if (nextTransId != null) {
                 List<String> transId = nextTransId.getString();
@@ -73,14 +78,24 @@ public class StartAuthnAttemptRequestMapper {
                     transIds = transId.stream().collect(Collectors.joining(","));
                 }
             }
+            confirmationCode = results.getConfirmationCode();
         }
+
+        if (error != null) {
+            errorCode = error.getErrorCode();
+            errorMessage = error.getMessage();
+        }
+
         LOGGER.info(
-                "question response: urn: {}, authRefNo: {}, outcome: {}, authenticationResult: {}, transIds: {}",
+                "question response: urn: {}, authRefNo: {}, outcome: {}, authenticationResult: {}, transIds: {}, error code: {}, error message: {}, confirmation code: {}",
                 urn,
                 authRefNo,
                 outcome,
                 authenticationResult,
-                transIds);
+                transIds,
+                errorCode,
+                errorMessage,
+                confirmationCode);
     }
 
     private SAARequest createRequest(QuestionRequest questionRequest) {


### PR DESCRIPTION
We need to further observe what's in the response payload of experian
When there are no questions KBV should throw an error instead, of returning a badRequest