### PR TITLE
KBV-531 Add aws-cli to acceptance test image

### DIFF
--- a/acceptance-tests/journey/Dockerfile
+++ b/acceptance-tests/journey/Dockerfile
@@ -1,3 +1,4 @@
 FROM gradle:jdk11
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install
 COPY . .
 ENTRYPOINT ["./run-tests.sh"]

--- a/acceptance-tests/journey/run-tests.sh
+++ b/acceptance-tests/journey/run-tests.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -eu
 REPORT_DIR="${TEST_REPORT_DIR:=$PWD}"
+echo aws-cli version is "$(aws --version)"
 
 IPV_CORE_STUB_START_URL=$PIPELINE_START_URL \
 IPV_CORE_STUB_AUTH_USERNAME=$PIPELINE_BASIC_AUTH_USERNAME \
 IPV_CORE_STUB_AUTH_PASSWORD=$PIPELINE_BASIC_AUTH_PASSWORD \
 gradle -q test
-
 cp -r build/test-results/* "$REPORT_DIR"

--- a/acceptance-tests/journey/src/test/java/uk/gov/di/ipv/cri/kbv/acceptancetest/journey/KBVJourneyTest.java
+++ b/acceptance-tests/journey/src/test/java/uk/gov/di/ipv/cri/kbv/acceptancetest/journey/KBVJourneyTest.java
@@ -47,7 +47,7 @@ class KBVJourneyTest {
         assertTrue(pageAsText.contains("Question 1"));
         assertTrue(pageAsText.contains("Correct 1"));
         assertTrue(pageAsText.contains("Incorrect 1"));
-        HtmlForm form = selectAnswer(page, "Q00001", 2, answerIndex);
+        HtmlForm form = selectAnswer(page, "Q00001", answerIndex);
         return clickContinueButton(form);
     }
 
@@ -57,23 +57,17 @@ class KBVJourneyTest {
         assertTrue(pageAsText.contains("Question 2"));
         assertTrue(pageAsText.contains("Correct 2"));
         assertTrue(pageAsText.contains("Incorrect 2"));
-        HtmlForm form = selectAnswer(page, "Q00002", 3, answerIndex);
+        HtmlForm form = selectAnswer(page, "Q00002", answerIndex);
         return clickContinueButton(form);
     }
 
     private HtmlForm selectAnswer(
-            HtmlPage page, String questionId, int expectedAnswers, int answerIndex) {
+            HtmlPage page, String questionId, int answerIndex) {
         List<HtmlForm> forms = page.getForms();
         assertNotNull(forms, "no forms on page");
         assertEquals(1, forms.size(), "unexpected number of forms on page");
         HtmlForm form = forms.get(0);
         List<HtmlRadioButtonInput> answers = form.getRadioButtonsByName(questionId);
-        assertEquals(
-                expectedAnswers,
-                answers.size(),
-                String.format(
-                        "unexpected number of answers: %d, expected: %d",
-                        answers.size(), expectedAnswers));
         HtmlRadioButtonInput question = answers.get(answerIndex);
         question.setChecked(true);
         return form;

--- a/acceptance-tests/journey/src/test/java/uk/gov/di/ipv/cri/kbv/acceptancetest/journey/KBVJourneyTest.java
+++ b/acceptance-tests/journey/src/test/java/uk/gov/di/ipv/cri/kbv/acceptancetest/journey/KBVJourneyTest.java
@@ -61,8 +61,7 @@ class KBVJourneyTest {
         return clickContinueButton(form);
     }
 
-    private HtmlForm selectAnswer(
-            HtmlPage page, String questionId, int answerIndex) {
+    private HtmlForm selectAnswer(HtmlPage page, String questionId, int answerIndex) {
         List<HtmlForm> forms = page.getForms();
         assertNotNull(forms, "no forms on page");
         assertEquals(1, forms.size(), "unexpected number of forms on page");


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

* [Add aws-cli to acceptance test image](https://github.com/alphagov/di-ipv-cri-kbv-api/commit/a074b2f249d94cf7004a716dfa05a96d01f4e2d1)
* [Relax assertion on number of expected answers on a KBV page](https://github.com/alphagov/di-ipv-cri-kbv-api/commit/3a1641c0cd2dd9ea0ad5ed6b3031da7c0f0a0736)

This was tested with:
````
cd acceptance-tests/journey
docker run -v $(pwd):/home/gradle/build/reports/tests -e PIPELINE_START_URL=xxxxxxxxx -e PIPELINE_BASIC_AUTH_USERNAME=xxxx -e PIPELINE_BASIC_AUTH_PASSWORD=xxxx --rm -it $(docker build -q .)
````
☝️ and this all runs clean and prints out the `aws-cli` version.

### Why did it change

The AWS CodePipeline was failing as it expects the test container to have the aws-cli installed.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-531](https://govukverify.atlassian.net/browse/KBV-531)
