### PR TITLE
KBV-531 run acceptance test script from root dir

### DIFF
--- a/acceptance-tests/journey/Dockerfile
+++ b/acceptance-tests/journey/Dockerfile
@@ -1,4 +1,5 @@
 FROM gradle:jdk11
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install
 COPY . .
-ENTRYPOINT ["./run-tests.sh"]
+RUN mv run-tests.sh /run-tests.sh
+ENTRYPOINT ["/run-tests.sh"]

--- a/acceptance-tests/journey/run-tests.sh
+++ b/acceptance-tests/journey/run-tests.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -eu
 REPORT_DIR="${TEST_REPORT_DIR:=$PWD}"
-echo aws-cli version is "$(aws --version)"
-
+pushd /home/gradle
 IPV_CORE_STUB_START_URL=$PIPELINE_START_URL \
 IPV_CORE_STUB_AUTH_USERNAME=$PIPELINE_BASIC_AUTH_USERNAME \
 IPV_CORE_STUB_AUTH_PASSWORD=$PIPELINE_BASIC_AUTH_PASSWORD \
 gradle -q test
-cp -r build/test-results/* "$REPORT_DIR"
+popd
+cp -r /home/gradle/build/test-results "$REPORT_DIR"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

The `run-tests.sh` script must be placed in root.

I've tested this change by building an ECR image from `acceptance-tests/journey` and using this ECR image uri in the Test CodeBuild stage on `di-ipv-cri-dev`. The tests pass and write to the report correctly, see:

<img width="600" alt="Screenshot 2022-06-29 at 06 25 57" src="https://user-images.githubusercontent.com/137389/176358330-b78ce173-f255-4e2c-ba29-7bb5d319e71f.png">


### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-531](https://govukverify.atlassian.net/browse/KBV-531)
