### PR TITLE
KBV-617 Ensure that only addresses with a validFrom field are sent in the Exp…

### DIFF
--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/gateway/StartAuthnAttemptRequestMapperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/gateway/StartAuthnAttemptRequestMapperTest.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.cri.kbv.api.gateway;
 
+import com.experian.uk.schema.experian.identityiq.services.webservice.LocationDetails;
 import com.experian.uk.schema.experian.identityiq.services.webservice.SAARequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -8,11 +9,14 @@ import uk.gov.di.ipv.cri.common.library.domain.personidentity.AddressType;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionRequest;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.gov.di.ipv.cri.kbv.api.util.TestDataCreator.createTestQuestionAnswerRequest;
+import static uk.gov.di.ipv.cri.kbv.api.util.TestDataCreator.createTestQuestionAnswerRequestWithDuplicateAddresses;
 
 class StartAuthnAttemptRequestMapperTest {
     private StartAuthnAttemptRequestMapper startAuthnAttemptRequestMapper;
@@ -72,6 +76,19 @@ class StartAuthnAttemptRequestMapperTest {
                         assertEquals(
                                 personAddress.getStreetName(),
                                 result.getLocationDetails().get(0).getUKLocation().getStreet()));
+    }
+
+    @Test
+    void shouldOnlyMapAddressWithAValidFromValue() {
+        questionRequest =
+                createTestQuestionAnswerRequestWithDuplicateAddresses(AddressType.CURRENT);
+        assertEquals(2, questionRequest.getPersonIdentity().getAddresses().size());
+        PersonIdentity personIdentity = questionRequest.getPersonIdentity();
+        SAARequest result = startAuthnAttemptRequestMapper.mapQuestionRequest(questionRequest);
+
+        assertNotNull(result);
+        List<LocationDetails> locationDetails = result.getLocationDetails();
+        assertEquals(1, locationDetails.size());
     }
 
     @Test

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/util/TestDataCreator.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/util/TestDataCreator.java
@@ -8,6 +8,7 @@ import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswerRequest;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionRequest;
 
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 public class TestDataCreator {
@@ -18,7 +19,26 @@ public class TestDataCreator {
         address.setPostalCode("Postcode");
         address.setStreetName("Street name");
         address.setAddressLocality("PostTown");
+        address.setValidFrom(LocalDate.now().minus(2, ChronoUnit.YEARS));
         personIdentity.setAddresses(List.of(address));
+        return personIdentity;
+    }
+
+    public static PersonIdentity createTestPersonIdentityWithDuplicateAddresses(
+            AddressType addressType) {
+        PersonIdentity personIdentity = new PersonIdentity();
+        personIdentity.setDateOfBirth(LocalDate.of(1976, 12, 26));
+        Address address1 = new Address();
+        address1.setPostalCode("Postcode");
+        address1.setStreetName("Street name");
+        address1.setAddressLocality("PostTown");
+        address1.setValidFrom(LocalDate.now().minus(2, ChronoUnit.YEARS));
+
+        Address address2 = new Address();
+        address2.setPostalCode("Postcode");
+        address2.setStreetName("Street name");
+        address2.setAddressLocality("PostTown");
+        personIdentity.setAddresses(List.of(address1, address2));
         return personIdentity;
     }
 
@@ -39,6 +59,16 @@ public class TestDataCreator {
         questionRequest.setUrn("urn");
         questionRequest.setStrategy("1 out of 2");
         questionRequest.setPersonIdentity(createTestPersonIdentity(addressType));
+        return questionRequest;
+    }
+
+    public static QuestionRequest createTestQuestionAnswerRequestWithDuplicateAddresses(
+            AddressType addressType) {
+        QuestionRequest questionRequest = new QuestionRequest();
+        questionRequest.setUrn("urn");
+        questionRequest.setStrategy("1 out of 2");
+        questionRequest.setPersonIdentity(
+                createTestPersonIdentityWithDuplicateAddresses(addressType));
         return questionRequest;
     }
 }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Ensure that only addresses with a validFrom field are sent in the Experian request.

We are currently getting duplicates of each address - one of the addresses contains the `validFrom` field while the other does not.

Filter out addresses that do not have a validFrom field.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-617](https://govukverify.atlassian.net/browse/KBV-617)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks