### PR TITLE
KBV-605: Enable VC score of Zero for user with a thin file

### DIFF
--- a/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
+++ b/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
@@ -149,11 +149,10 @@ public class QuestionAnswerHandler
                 && questionsResponse.hasQuestionRequestEnded()) {
             var serializedQuestionState = objectMapper.writeValueAsString(questionState);
             kbvItem.setQuestionState(serializedQuestionState);
-            kbvItem.setStatus(questionsResponse.getStatus());
+            kbvItem.setStatus(questionsResponse.getAuthenticationResult());
             kbvStorageService.update(kbvItem);
             SessionItem sessionItem =
                     sessionService.getSession(String.valueOf(kbvItem.getSessionId()));
-            sessionItem.setAuthorizationCode(UUID.randomUUID().toString());
             sessionService.createAuthorizationCode(sessionItem);
             auditService.sendAuditEvent(
                     AuditEventType.THIRD_PARTY_REQUEST_ENDED,
@@ -180,7 +179,7 @@ public class QuestionAnswerHandler
 
     private Map<String, Object> createAuditEventContext(QuestionsResponse questionsResponse) {
         Map<String, Object> contextEntries = new HashMap<>();
-        contextEntries.put("outcome", questionsResponse.getStatus());
+        contextEntries.put("outcome", questionsResponse.getAuthenticationResult());
         if (Objects.nonNull(questionsResponse.getResults())
                 && Objects.nonNull(questionsResponse.getResults().getQuestions())) {
             ResultsQuestions questionSummary = questionsResponse.getResults().getQuestions();

--- a/lambdas/answer/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandlerTest.java
+++ b/lambdas/answer/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandlerTest.java
@@ -145,7 +145,7 @@ class QuestionAnswerHandlerTest {
 
         when(questionsResponseMock.hasQuestions()).thenReturn(false);
         when(questionsResponseMock.hasQuestionRequestEnded()).thenReturn(true);
-        when(questionsResponseMock.getStatus()).thenReturn(responseStatus);
+        when(questionsResponseMock.getAuthenticationResult()).thenReturn(responseStatus);
 
         SessionItem mockSessionItem = mock(SessionItem.class);
         when(mockSessionService.getSession(String.valueOf(kbvItemMock.getSessionId())))

--- a/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
+++ b/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
@@ -151,6 +151,7 @@ public class QuestionHandler
             return question;
         }
         if (questionsResponse != null && questionsResponse.hasQuestionRequestEnded()) {
+            saveQuestionStateToKbvItem(kbvItem, questionState, questionsResponse);
             return null;
         }
         throw new QuestionNotFoundException("Question not Found");
@@ -181,6 +182,7 @@ public class QuestionHandler
         kbvItem.setAuthRefNo(questionsResponse.getControl().getAuthRefNo());
         kbvItem.setUrn(questionsResponse.getControl().getURN());
         kbvItem.setExpiryDate(this.configurationService.getSessionExpirationEpoch());
+        kbvItem.setStatus(questionsResponse.getStatus());
 
         kbvStorageService.save(kbvItem);
     }

--- a/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
+++ b/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
@@ -100,7 +100,8 @@ public class QuestionHandler
                 kbvItem = new KBVItem();
                 kbvItem.setSessionId(sessionId);
             }
-            if (Objects.nonNull(kbvItem.getStatus()) && kbvItem.getStatus().equalsIgnoreCase("END")) {
+            if (Objects.nonNull(kbvItem.getStatus())
+                    && kbvItem.getStatus().equalsIgnoreCase("END")) {
                 response.withStatusCode(HttpStatusCode.NO_CONTENT);
                 eventProbe.counterMetric(GET_QUESTION);
                 return response;

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/QuestionsResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/QuestionsResponse.java
@@ -40,18 +40,22 @@ public class QuestionsResponse {
     }
 
     public boolean hasQuestionRequestEnded() {
-        if (StringUtils.isNotBlank(this.getQuestionStatus())) {
-            return this.getQuestionStatus().equalsIgnoreCase("END");
+        if (StringUtils.isNotBlank(this.getTransactionState())) {
+            return this.getTransactionState().equalsIgnoreCase("END");
         }
         return false;
     }
 
-    public String getQuestionStatus() {
+    public String getTransactionState() {
         return results.getNextTransId().getString().stream().collect(Collectors.joining(""));
     }
 
-    public String getStatus() {
+    public String getAuthenticationResult() {
         return results.getAuthenticationResult();
+    }
+
+    public String getOutcome() {
+        return results.getOutcome();
     }
 
     public void setResults(Results results) {


### PR DESCRIPTION
## Proposed changes
see: https://govukverify.atlassian.net/browse/KBV-605

When making the first request is made, if the response is Insufficient questions and the experian session Ends.
When this outcome is encountered, the question lambda must:

- return a 204 status code to the KBV frontend. 
- write this outcome to the KBV DDB table as the status for this session
- Create an authorization code in the Session DDB table

### What changed

The situation is as a result of users with a thin file i.e. they don't have a sufficient data with Experian and as a result there Experian KBV journey ends

### Why did it change

Currently, the service errors, it should now be possible to generate a VC with a score of zero
and allow IPV CORE to continue alternate flow for the user


- [KBV-605](https://govukverify.atlassian.net/browse/KBV-605)

