### PR TITLE
KBV-621 send result and error metrics to cloudwatch

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGatewayFactory.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGatewayFactory.java
@@ -3,11 +3,13 @@ package uk.gov.di.ipv.cri.kbv.api.gateway;
 import com.experian.uk.schema.experian.identityiq.services.webservice.IdentityIQWebService;
 import com.experian.uk.wasp.TokenService;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.kbv.api.security.Base64TokenCacheLoader;
 import uk.gov.di.ipv.cri.kbv.api.security.HeaderHandler;
 import uk.gov.di.ipv.cri.kbv.api.security.HeaderHandlerResolver;
 import uk.gov.di.ipv.cri.kbv.api.security.KBVClientFactory;
 import uk.gov.di.ipv.cri.kbv.api.security.SoapToken;
+import uk.gov.di.ipv.cri.kbv.api.service.MetricsService;
 
 public class KBVGatewayFactory {
     public static final String IIQ_DATABASE_MODE_PARAM_NAME = "IIQDatabaseMode";
@@ -26,12 +28,14 @@ public class KBVGatewayFactory {
 
         new KeyStoreLoader(configurationService).load();
 
+        MetricsService metricsService = new MetricsService(new EventProbe());
         this.kbvGateway =
                 new KBVGateway(
                         new StartAuthnAttemptRequestMapper(
                                 configurationService.getParameterValue(
-                                        IIQ_DATABASE_MODE_PARAM_NAME)),
-                        new ResponseToQuestionMapper(),
+                                        IIQ_DATABASE_MODE_PARAM_NAME),
+                                metricsService),
+                        new ResponseToQuestionMapper(metricsService),
                         new KBVClientFactory(
                                         new IdentityIQWebService(),
                                         new HeaderHandlerResolver(headerHandler),

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/StartAuthnAttemptRequestMapper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/StartAuthnAttemptRequestMapper.java
@@ -19,6 +19,7 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionRequest;
+import uk.gov.di.ipv.cri.kbv.api.service.MetricsService;
 import uk.gov.di.ipv.cri.kbv.api.util.StringUtils;
 
 import javax.xml.bind.JAXBContext;
@@ -42,9 +43,11 @@ public class StartAuthnAttemptRequestMapper {
     public static final String DEFAULT_STRATEGY = "3 out of 4";
     public static final String DEFAULT_TITLE = "MR";
     private String testDatabase;
+    private MetricsService metricsService;
 
-    public StartAuthnAttemptRequestMapper(String testDatabase) {
+    public StartAuthnAttemptRequestMapper(String testDatabase, MetricsService metricsService) {
         this.testDatabase = testDatabase;
+        this.metricsService = metricsService;
     }
 
     public SAARequest mapQuestionRequest(QuestionRequest questionRequest) {
@@ -109,6 +112,9 @@ public class StartAuthnAttemptRequestMapper {
                     errorMessage,
                     confirmationCode);
         }
+
+        metricsService.sendResultMetric(results, "initial_questions_response");
+        metricsService.sendErrorMetric(error, "initial_questions_response_error");
     }
 
     private SAARequest createRequest(QuestionRequest questionRequest) {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/MetricsService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/MetricsService.java
@@ -1,0 +1,49 @@
+package uk.gov.di.ipv.cri.kbv.api.service;
+
+import com.experian.uk.schema.experian.identityiq.services.webservice.ArrayOfString;
+import com.experian.uk.schema.experian.identityiq.services.webservice.Error;
+import com.experian.uk.schema.experian.identityiq.services.webservice.Results;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class MetricsService {
+
+    public static final String OUTCOME = "outcome";
+    public static final String TRANS_ID = "transId";
+    public static final String ERROR_CODE = "error_code";
+    private final EventProbe eventProbe;
+
+    public MetricsService(EventProbe eventProbe) {
+        this.eventProbe = eventProbe;
+    }
+
+    public void sendErrorMetric(Error error, String metricName) {
+        if (error != null && error.getErrorCode() != null) {
+            String errorCode = error.getErrorCode();
+            eventProbe.addDimensions(Map.of(ERROR_CODE, errorCode));
+            eventProbe.counterMetric(metricName);
+        }
+    }
+
+    public void sendResultMetric(Results results, String metricName) {
+        if (results != null) {
+            String outcome = results.getOutcome();
+            ArrayOfString nextTransId = results.getNextTransId();
+            String transIds = "";
+            if (nextTransId != null) {
+                List<String> transId = nextTransId.getString();
+                if (transId != null) {
+                    transIds = transId.stream().collect(Collectors.joining(","));
+                }
+            }
+
+            if (outcome != null && !outcome.isBlank()) {
+                eventProbe.addDimensions(Map.of(OUTCOME, outcome, TRANS_ID, transIds));
+                eventProbe.counterMetric(metricName);
+            }
+        }
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/MetricsService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/MetricsService.java
@@ -12,7 +12,7 @@ import java.util.stream.Collectors;
 public class MetricsService {
 
     public static final String OUTCOME = "outcome";
-    public static final String TRANS_ID = "transId";
+    public static final String TRANS_ID = "transition_id";
     public static final String ERROR_CODE = "error_code";
     private final EventProbe eventProbe;
 

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/gateway/ResponseToQuestionMapperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/gateway/ResponseToQuestionMapperTest.java
@@ -1,22 +1,47 @@
 package uk.gov.di.ipv.cri.kbv.api.gateway;
 
+import com.experian.uk.schema.experian.identityiq.services.webservice.Error;
 import com.experian.uk.schema.experian.identityiq.services.webservice.RTQRequest;
+import com.experian.uk.schema.experian.identityiq.services.webservice.RTQResponse2;
+import com.experian.uk.schema.experian.identityiq.services.webservice.Results;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswerRequest;
+import uk.gov.di.ipv.cri.kbv.api.service.MetricsService;
 import uk.gov.di.ipv.cri.kbv.api.util.TestDataCreator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class ResponseToQuestionMapperTest {
     private ResponseToQuestionMapper responseToQuestionMapper;
     private QuestionAnswerRequest questionAnswerRequest;
 
+    @Mock private MetricsService metricsService;
+
     @BeforeEach
     void setup() {
-        responseToQuestionMapper = new ResponseToQuestionMapper();
+        responseToQuestionMapper = new ResponseToQuestionMapper(metricsService);
+    }
+
+    @Test
+    void shouldSendMetrics() {
+        RTQResponse2 response = mock(RTQResponse2.class);
+        Results results = mock(Results.class);
+        when(response.getResults()).thenReturn(results);
+        Error error = mock(Error.class);
+        when(response.getError()).thenReturn(error);
+        responseToQuestionMapper.mapRTQResponse2ToMapQuestionsResponse(response);
+        verify(metricsService).sendResultMetric(results, "submit_questions_response");
+        verify(metricsService).sendErrorMetric(error, "submit_questions_response_error");
     }
 
     @Test

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/MetricsServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/MetricsServiceTest.java
@@ -1,0 +1,52 @@
+package uk.gov.di.ipv.cri.kbv.api.service;
+
+import com.experian.uk.schema.experian.identityiq.services.webservice.ArrayOfString;
+import com.experian.uk.schema.experian.identityiq.services.webservice.Error;
+import com.experian.uk.schema.experian.identityiq.services.webservice.Results;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.cri.kbv.api.service.MetricsService.ERROR_CODE;
+import static uk.gov.di.ipv.cri.kbv.api.service.MetricsService.OUTCOME;
+import static uk.gov.di.ipv.cri.kbv.api.service.MetricsService.TRANS_ID;
+
+@ExtendWith(MockitoExtension.class)
+class MetricsServiceTest {
+
+    @Mock private EventProbe eventProbe;
+
+    @Mock Results results;
+
+    @Mock Error error;
+
+    @Mock ArrayOfString arrayOfString;
+
+    @Test
+    void shouldSendResultsMetric() {
+        MetricsService metricsService = new MetricsService(eventProbe);
+
+        when(results.getOutcome()).thenReturn("foo");
+        when(results.getNextTransId()).thenReturn(arrayOfString);
+        when(arrayOfString.getString()).thenReturn(List.of("bar"));
+        metricsService.sendResultMetric(results, "baz");
+        verify(eventProbe).counterMetric("baz");
+        verify(eventProbe).addDimensions(Map.of(OUTCOME, "foo", TRANS_ID, "bar"));
+    }
+
+    @Test
+    void shouldSendErrorMetric() {
+        MetricsService metricsService = new MetricsService(eventProbe);
+        when(error.getErrorCode()).thenReturn("oh no!");
+        metricsService.sendErrorMetric(error, "baz");
+        verify(eventProbe).counterMetric("baz");
+        verify(eventProbe).addDimensions(Map.of(ERROR_CODE, "oh no!"));
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Send result and error metrics to cloudwatch.

### What changed

Add a new MetricsService that sends 4 metrics with dimensions:

1. initial_questions_response, dimensions: outcome, transId
2. initial_questions_response_error, dimensions: errorCode
3. submit_questions_response, dimensions: outcome, transId
4. submit_questions_response_error, dimensions: errorCode

Co-authored with @jkunle and @amanmsirius 

### Why did it change

We need to get a better dashboard view of the results of IIQ API calls.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-621](https://govukverify.atlassian.net/browse/KBV-621)
