### PR TITLE
KBV-605 Add DDB read & write policy for QuestionFunction

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -462,6 +462,10 @@ Resources:
         - DynamoDBWritePolicy:
             TableName: !Ref KBVTable
         - DynamoDBReadPolicy:
+            TableName: !Ref SessionTable
+        - DynamoDBWritePolicy:
+            TableName: !Ref SessionTable
+        - DynamoDBReadPolicy:
             TableName: !Ref PersonIdentityTable
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

The question lambda needs the ability to write an auth code to DDB, and read txma-related data.

We made this change on a dev stack but forgot to commit this rather important bit to a previous PR.

## Why?

The question lambda now has the ability to exit the user journey when we retrieve the first questions, so it needs to write an auth code to the session table, and read some data for a TxMA event.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-605](https://govukverify.atlassian.net/browse/KBV-605)
