### PR TITLE
KBV-605 User with insufficient questions gets a VC JWT

### DIFF
--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
@@ -139,21 +139,10 @@ public class VerifiableCredentialService {
         Evidence evidence = new Evidence();
         evidence.setTxn(kbvItem.getAuthRefNo());
 
-        if (kbvItem.getStatus() == null) {
-            throw new IllegalArgumentException("KBV item status is null");
-        }
-
-        switch (kbvItem.getStatus().toUpperCase()) {
-            case VC_THIRD_PARTY_KBV_CHECK_PASS:
-                evidence.setVerificationScore(VC_PASS_EVIDENCE_SCORE);
-                break;
-            case VC_THIRD_PARTY_KBV_CHECK_NOT_AUTHENTICATED:
-            case VC_THIRD_PARTY_KBV_CHECK_UNABLE_TO_AUTHENTICATE:
-            case VC_THIRD_PARTY_KBV_CHECK_ABANDONED:
-                evidence.setVerificationScore(VC_FAIL_EVIDENCE_SCORE);
-                break;
-            default:
-                throw new IllegalArgumentException("KBV item status is unknown");
+        if (VC_THIRD_PARTY_KBV_CHECK_PASS.equalsIgnoreCase(kbvItem.getStatus())) {
+            evidence.setVerificationScore(VC_PASS_EVIDENCE_SCORE);
+        } else {
+            evidence.setVerificationScore(VC_FAIL_EVIDENCE_SCORE);
         }
 
         return new Map[] {objectMapper.convertValue(evidence, Map.class)};

--- a/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
+++ b/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
@@ -173,8 +173,9 @@ public class QuestionHandler
             return question;
         }
         var questionsResponse = getQuestionAnswerResponse(kbvItem);
+        question = getQuestionFromResponse(questionsResponse, questionState);
         saveQuestionStateToKbvItem(kbvItem, questionState, questionsResponse);
-        if ((question = getQuestionFromResponse(questionsResponse, questionState)) != null) {
+        if (question != null) {
             return question;
         } else {
             setAuthCode(kbvItem);

--- a/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
+++ b/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.experian.uk.schema.experian.identityiq.services.webservice.Question;
+import com.experian.uk.schema.experian.identityiq.services.webservice.ResultsQuestions;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -16,9 +17,11 @@ import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverage
 import uk.gov.di.ipv.cri.common.library.domain.AuditEventType;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentityDetailed;
 import uk.gov.di.ipv.cri.common.library.exception.SqsException;
+import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
 import uk.gov.di.ipv.cri.common.library.service.AuditService;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.common.library.service.PersonIdentityService;
+import uk.gov.di.ipv.cri.common.library.service.SessionService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswerRequest;
@@ -31,6 +34,7 @@ import uk.gov.di.ipv.cri.kbv.api.service.KBVService;
 import uk.gov.di.ipv.cri.kbv.api.service.KBVStorageService;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
@@ -124,8 +128,7 @@ public class QuestionHandler
             response.withBody("{ " + ERROR_KEY + ":\"" + npe + "\" }");
         } catch (QuestionNotFoundException qe) {
             eventProbe.log(ERROR, qe).counterMetric(GET_QUESTION, 0d);
-            response.withStatusCode(HttpStatusCode.INTERNAL_SERVER_ERROR);
-            response.withBody("{ " + ERROR_KEY + ":\"" + qe.getMessage() + "\" }");
+            response.withStatusCode(HttpStatusCode.NO_CONTENT);
         } catch (IOException e) {
             eventProbe.log(ERROR, e).counterMetric(GET_QUESTION, 0d);
             response.withStatusCode(HttpStatusCode.INTERNAL_SERVER_ERROR);

--- a/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
+++ b/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
@@ -173,13 +173,14 @@ public class QuestionHandler
             return question;
         }
         var questionsResponse = getQuestionAnswerResponse(kbvItem);
+        saveQuestionStateToKbvItem(kbvItem, questionState, questionsResponse);
         if ((question = getQuestionFromResponse(questionsResponse, questionState)) != null) {
-            saveQuestionStateToKbvItem(kbvItem, questionState, questionsResponse);
             return question;
+        } else {
+            setAuthCode(kbvItem);
+            sendNoQuestionAuditEvent(questionsResponse);
+            throw new QuestionNotFoundException("No questions available");
         }
-        setAuthCode(kbvItem);
-        sendNoQuestionAuditEvent(questionsResponse);
-        throw new QuestionNotFoundException("No questions available");
     }
 
     private Question getQuestionFromDbStore(QuestionState questionState) {

--- a/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
+++ b/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
@@ -9,10 +9,13 @@ import com.experian.uk.schema.experian.identityiq.services.webservice.Question;
 import com.experian.uk.schema.experian.identityiq.services.webservice.Questions;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.Level;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -24,9 +27,11 @@ import software.amazon.awssdk.services.dynamodb.model.InternalServerErrorExcepti
 import uk.gov.di.ipv.cri.common.library.domain.AuditEventType;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentityDetailed;
 import uk.gov.di.ipv.cri.common.library.exception.SqsException;
+import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
 import uk.gov.di.ipv.cri.common.library.service.AuditService;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.common.library.service.PersonIdentityService;
+import uk.gov.di.ipv.cri.common.library.service.SessionService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswer;
@@ -44,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -51,6 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -71,6 +78,9 @@ class QuestionHandlerTest {
     @Mock private KBVGateway mockKBVGateway;
     @Mock private ConfigurationService mockConfigurationService;
     @Mock private AuditService mockAuditService;
+    @Mock private SessionService sessionService;
+    @Captor private ArgumentCaptor<Map<String, Object>> captor;
+
     private KBVService spyKBVService;
 
     @BeforeEach
@@ -84,7 +94,8 @@ class QuestionHandlerTest {
                         spyKBVService,
                         mockConfigurationService,
                         mockEventProbe,
-                        mockAuditService);
+                        mockAuditService,
+                        sessionService);
     }
 
     @Nested
@@ -171,8 +182,9 @@ class QuestionHandlerTest {
         }
 
         @Test
-        void shouldReturn500ErrorWhenThereAreNoFurtherQuestions() throws IOException {
+        void shouldReturn204WhenThereAreNoQuestions() throws IOException {
             Context contextMock = mock(Context.class);
+            QuestionsResponse questionsResponse = mock(QuestionsResponse.class);
             APIGatewayProxyRequestEvent input = mock(APIGatewayProxyRequestEvent.class);
             Map<String, String> sessionHeader =
                     Map.of(HEADER_SESSION_ID, UUID.randomUUID().toString());
@@ -182,6 +194,8 @@ class QuestionHandlerTest {
             KBVItem kbvItem = new KBVItem();
             kbvItem.setSessionId(UUID.fromString(sessionHeader.get(HEADER_SESSION_ID)));
             QuestionState questionStateMock = mock(QuestionState.class);
+            when(mockKBVGateway.getQuestions(any(QuestionRequest.class)))
+                    .thenReturn(questionsResponse);
 
             when(input.getHeaders()).thenReturn(sessionHeader);
             when(mockKBVStorageService.getKBVItem(
@@ -196,7 +210,8 @@ class QuestionHandlerTest {
             APIGatewayProxyResponseEvent response =
                     questionHandler.handleRequest(input, contextMock);
 
-            assertEquals(HttpStatusCode.INTERNAL_SERVER_ERROR, response.getStatusCode());
+            assertEquals(HttpStatusCode.NO_CONTENT, response.getStatusCode());
+            assertNull(response.getBody());
 
             verify(mockKBVStorageService)
                     .getKBVItem(UUID.fromString(sessionHeader.get(HEADER_SESSION_ID)));
@@ -204,7 +219,6 @@ class QuestionHandlerTest {
             verify(mockPersonIdentityService).getPersonIdentityDetailed(kbvItem.getSessionId());
             verify(mockObjectMapper).readValue(kbvItem.getQuestionState(), QuestionState.class);
             verify(mockEventProbe).counterMetric(GET_QUESTION, 0d);
-            assertEquals("{ \"error\":\"Question not Found\" }", response.getBody());
         }
 
         @Test
@@ -347,13 +361,34 @@ class QuestionHandlerTest {
     @Nested
     class ProcessQuestionRequest {
         @Test
-        void shouldThrowQuestionNotFoundExceptionWhenQuestionStateAndKbvItemEmptyObjects() {
+        void shouldThrowQuestionNotFoundExceptionWhenQuestionStateAndKbvItemEmptyObjects()
+                throws SqsException {
+            String expectedOutcome = "Insufficient Questions (Unable to Authenticate)";
+            UUID sessionId = UUID.randomUUID();
+            KBVItem kbvItem = mock(KBVItem.class);
+            SessionItem sessionItem = mock(SessionItem.class);
+            QuestionsResponse questionsResponse = mock(QuestionsResponse.class);
+            when(kbvItem.getSessionId()).thenReturn(sessionId);
+            when(questionsResponse.getStatus()).thenReturn(expectedOutcome);
+
+            when(mockKBVGateway.getQuestions(any(QuestionRequest.class)))
+                    .thenReturn(questionsResponse);
+            when(sessionService.getSession(sessionId.toString())).thenReturn(sessionItem);
+
             assertThrows(
                     QuestionNotFoundException.class,
-                    () ->
-                            questionHandler.processQuestionRequest(
-                                    new QuestionState(), new KBVItem()),
+                    () -> {
+                        questionHandler.processQuestionRequest(new QuestionState(), kbvItem);
+                    },
                     "Question not Found");
+            verify(sessionService).createAuthorizationCode(sessionItem);
+            verify(mockAuditService)
+                    .sendAuditEvent(eq(AuditEventType.THIRD_PARTY_REQUEST_ENDED), captor.capture());
+
+            Map<String, Object> response =
+                    (Map<String, Object>) captor.getValue().get("experianIiqResponse");
+            String outcome = (String) response.get("outcome");
+            assertThat(outcome, Matchers.equalTo(expectedOutcome));
         }
 
         @Test


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

A user with Insufficient initial questions to authenticate should be issued a verifiable credential with a verification score of zero.

The user experience at present is that the user sees a technical error page.


### What changed


* [Send a verificationScore of 0 in all cases except when the result of …](https://github.com/alphagov/di-ipv-cri-kbv-api/commit/cbcab1bd3d0d9a53ae2133b465f1fbbaa219ef37)
* [set authorization code and TxMA event when there are no questions ret…](https://github.com/alphagov/di-ipv-cri-kbv-api/commit/8146b24193f709783c5090e9cc0970b90f0b8358)
* [return http status 204 on QuestionNotFoundException](https://github.com/alphagov/di-ipv-cri-kbv-api/commit/92e274a4e2701218853860f535446e2a5447ad98)
* [test for returning http status 204 on QuestionNotFoundException](https://github.com/alphagov/di-ipv-cri-kbv-api/commit/59fd5af013c8001c815c0de0566201e80e679787)

<!-- Describe the changes in detail - the "what"-->



### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-605](https://govukverify.atlassian.net/browse/KBV-605)