### PR TITLE
Change IIQ API database mode from Aged to Static

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -86,10 +86,10 @@ Mappings:
 
   IIQAPIDatabaseModeMapping:
     Environment:
-      dev: Aged
-      build: Aged
-      staging: Aged
-      integration: Aged
+      dev: Static
+      build: Static
+      staging: Static
+      integration: Static
       production: Normal
 
   SessionTtlMapping:


### PR DESCRIPTION
### What changed

Amended `template.yaml` to switch test database mode for Experian IIQ API to `Static`

### Why did it change

As part of moving towards a more concrete UAT environment, changing the mode from `Aged` to `Static` for the `testDatabase` field in the payload

### Issue tracking

- [KBV-632](https://govukverify.atlassian.net/browse/KBV-632)
