### PR TITLE
FIX: Do not use the API key in dev

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -748,6 +748,7 @@ Resources:
         RateLimit: 50 # allowed requests per second
 
   LinkUsagePlanApiKey1:
+    Condition: IsNotDevEnvironment
     Type: AWS::ApiGateway::UsagePlanKey
     Properties:
       KeyId: !ImportValue core-infrastructure-ApiKey1
@@ -755,6 +756,7 @@ Resources:
       UsagePlanId: !Ref PublicApiUsagePlan
 
   LinkUsagePlanApiKey2:
+    Condition: IsNotDevEnvironment
     Type: AWS::ApiGateway::UsagePlanKey
     Properties:
       KeyId: !ImportValue core-infrastructure-ApiKey2


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Don't use API keys in the `dev` environment.

✅ Checked on a dev stack.

This migitates the issue of the API key from core being shared across many stacks in dev:

````
The Usage Plan limit for  API Key core-ixxxxxxxx has been reached
````

### Why did it change

Allow us to deploy however many stacks we wish to dev, using the same api key.
