### PR TITLE
Add IIQStrategy to AWS SSM

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -92,6 +92,14 @@ Mappings:
       integration: Static
       production: Normal
 
+  IIQAPIStrategyMapping:
+    Environment:
+      dev: 3 out of 4
+      build: 3 out of 4
+      staging: 3 out of 4
+      integration: 3 out of 4
+      production: 3 out of 4
+
   SessionTtlMapping:
     Environment:
       dev: 7200 # 2 hours
@@ -483,6 +491,7 @@ Resources:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/PersonIdentityTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/verifiable-credential/issuer"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/IIQDatabaseMode"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/IIQStrategy"
         - Statement:
             - Sid: ReadSecretsPolicy
               Effect: Allow
@@ -808,6 +817,14 @@ Resources:
       Type: String
       Value: !FindInMap [ IIQAPIDatabaseModeMapping, Environment, !Ref 'Environment' ]
       Description: "one of: S or Static, A or Aged, N or Normal (Live)"
+
+  IIQAPIStrategyParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/IIQStrategy"
+      Type: String
+      Value: !FindInMap [ IIQAPIStrategyMapping, Environment, !Ref 'Environment' ]
+      Description: Strategy to be used for Experian KBV Questions. Example - 3 of 4
 
   IPVCoreStubAuthenticationAlgParameter:
     Condition: IsStubEnvironment

--- a/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
+++ b/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
@@ -48,6 +48,7 @@ public class QuestionHandler
     public static final String HEADER_SESSION_ID = "session-id";
     public static final String GET_QUESTION = "get_question";
     public static final String ERROR_KEY = "\"error\"";
+    public static final String IIQ_STRATEGY_PARAM_NAME = "IIQStrategy";
     private final ObjectMapper objectMapper;
     private final KBVStorageService kbvStorageService;
     private final PersonIdentityService personIdentityService;
@@ -221,6 +222,8 @@ public class QuestionHandler
             PersonIdentityDetailed personIdentity =
                     personIdentityService.getPersonIdentityDetailed(kbvItem.getSessionId());
             QuestionRequest questionRequest = new QuestionRequest();
+            questionRequest.setStrategy(
+                    this.configurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME));
             questionRequest.setPersonIdentity(
                     personIdentityService.convertToPersonIdentitySummary(personIdentity));
             QuestionsResponse questionsResponse = this.kbvService.getQuestions(questionRequest);

--- a/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
+++ b/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
@@ -131,6 +131,7 @@ class QuestionHandlerTest {
             verify(mockPersonIdentityService).getPersonIdentityDetailed(kbvItem.getSessionId());
             verify(mockAuditService).sendAuditEvent(AuditEventType.REQUEST_SENT, personIdentity);
             verify(mockKBVStorageService).save(any());
+            verify(mockConfigurationService).getParameterValue("IIQStrategy");
             verify(mockObjectMapper, times(2)).writeValueAsString(any());
             verify(mockEventProbe).counterMetric(GET_QUESTION);
         }
@@ -177,6 +178,7 @@ class QuestionHandlerTest {
             verify(mockKBVStorageService)
                     .getKBVItem(UUID.fromString(sessionHeader.get(HEADER_SESSION_ID)));
             verify(mockObjectMapper).readValue(kbvItem.getQuestionState(), QuestionState.class);
+            verify(mockConfigurationService, times(0)).getParameterValue("IIQStrategy");
             verify(mockObjectMapper).writeValueAsString(unAnsweredQuestion);
             verify(mockEventProbe).counterMetric(GET_QUESTION);
         }
@@ -220,6 +222,7 @@ class QuestionHandlerTest {
 
             verify(mockPersonIdentityService).getPersonIdentityDetailed(kbvItem.getSessionId());
             verify(mockObjectMapper).readValue(kbvItem.getQuestionState(), QuestionState.class);
+            verify(mockConfigurationService).getParameterValue("IIQStrategy");
             verify(mockEventProbe).counterMetric(GET_QUESTION, 0d);
         }
 
@@ -357,6 +360,7 @@ class QuestionHandlerTest {
             assertEquals(HttpStatusCode.NO_CONTENT, response.getStatusCode());
             assertNull(response.getBody());
             verify(mockEventProbe).counterMetric(GET_QUESTION);
+            verify(mockConfigurationService, times(0)).getParameterValue("IIQStrategy");
         }
     }
 
@@ -399,6 +403,7 @@ class QuestionHandlerTest {
                     (Map<String, Object>) auditEventMap.getValue().get("experianIiqResponse");
             String outcome = (String) response.get("outcome");
             assertThat(outcome, equalTo(expectedOutcome));
+            verify(mockConfigurationService).getParameterValue("IIQStrategy");
         }
 
         @Test

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/StartAuthnAttemptRequestMapper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/StartAuthnAttemptRequestMapper.java
@@ -33,7 +33,6 @@ public class StartAuthnAttemptRequestMapper {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    public static final String DEFAULT_STRATEGY = "3 out of 4";
     public static final String DEFAULT_TITLE = "MR";
     private String testDatabase;
     private MetricsService metricsService;
@@ -137,7 +136,7 @@ public class StartAuthnAttemptRequestMapper {
         applicationData.setApplicationType("IG");
         applicationData.setChannel("IN");
         applicationData.setSearchConsent("Y");
-        applicationData.setProduct(StringUtils.isNotBlank(strategy) ? strategy : DEFAULT_STRATEGY);
+        applicationData.setProduct(strategy);
         saaRequest.setApplicationData(applicationData);
     }
 


### PR DESCRIPTION
We currently hardcode the IIQ strategy into the KBV API as `3 out of 4`

We should move this to an SSM parameter on AWS so that it can be configured for any environment

## Proposed changes

### What changed

Added new SSM in `template.yaml` called `IIQAPIStrategyParameter`

### Issue tracking

- [KBV-639](https://govukverify.atlassian.net/browse/KBV-639)

