### PR TITLE
Add IIQ Operator id for Experian

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -92,6 +92,14 @@ Mappings:
       integration: Static
       production: Normal
 
+  IIQOperatorIdMapping:
+    Environment:
+      dev: GDSCABINETUIIQ01U
+      build: GDSCABINETUIIQ01U
+      staging: GDSCABINETUIIQ01U
+      integration: GDSCABINETUIIQ01U
+      production: GDSCABINETUIIQ01U
+
   SessionTtlMapping:
     Environment:
       dev: 7200 # 2 hours
@@ -483,6 +491,7 @@ Resources:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/PersonIdentityTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/verifiable-credential/issuer"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/IIQDatabaseMode"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/IIQOperatorId"
         - Statement:
             - Sid: ReadSecretsPolicy
               Effect: Allow
@@ -808,6 +817,14 @@ Resources:
       Type: String
       Value: !FindInMap [ IIQAPIDatabaseModeMapping, Environment, !Ref 'Environment' ]
       Description: "one of: S or Static, A or Aged, N or Normal (Live)"
+
+  IIQOperatorIdParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/IIQOperatorId"
+      Type: String
+      Value: !FindInMap [ IIQOperatorIdMapping, Environment, !Ref 'Environment' ]
+      Description: Unique operator id provided by Experian to GDS
 
   IPVCoreStubAuthenticationAlgParameter:
     Condition: IsStubEnvironment

--- a/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
+++ b/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
@@ -48,6 +48,7 @@ public class QuestionHandler
     public static final String HEADER_SESSION_ID = "session-id";
     public static final String GET_QUESTION = "get_question";
     public static final String ERROR_KEY = "\"error\"";
+    private static final String IIQ_OPERATOR_ID_PARAM_NAME = "IIQOperatorId";
     private final ObjectMapper objectMapper;
     private final KBVStorageService kbvStorageService;
     private final PersonIdentityService personIdentityService;
@@ -221,6 +222,8 @@ public class QuestionHandler
             PersonIdentityDetailed personIdentity =
                     personIdentityService.getPersonIdentityDetailed(kbvItem.getSessionId());
             QuestionRequest questionRequest = new QuestionRequest();
+            questionRequest.setIiqOperatorId(
+                    this.configurationService.getParameterValue(IIQ_OPERATOR_ID_PARAM_NAME));
             questionRequest.setPersonIdentity(
                     personIdentityService.convertToPersonIdentitySummary(personIdentity));
             QuestionsResponse questionsResponse = this.kbvService.getQuestions(questionRequest);

--- a/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
+++ b/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
@@ -131,6 +131,7 @@ class QuestionHandlerTest {
             verify(mockPersonIdentityService).getPersonIdentityDetailed(kbvItem.getSessionId());
             verify(mockAuditService).sendAuditEvent(AuditEventType.REQUEST_SENT, personIdentity);
             verify(mockKBVStorageService).save(any());
+            verify(mockConfigurationService).getParameterValue("IIQOperatorId");
             verify(mockObjectMapper, times(2)).writeValueAsString(any());
             verify(mockEventProbe).counterMetric(GET_QUESTION);
         }
@@ -176,6 +177,7 @@ class QuestionHandlerTest {
             assertEquals(expectedQuestion, response.getBody());
             verify(mockKBVStorageService)
                     .getKBVItem(UUID.fromString(sessionHeader.get(HEADER_SESSION_ID)));
+            verify(mockConfigurationService, times(0)).getParameterValue("IIQOperatorId");
             verify(mockObjectMapper).readValue(kbvItem.getQuestionState(), QuestionState.class);
             verify(mockObjectMapper).writeValueAsString(unAnsweredQuestion);
             verify(mockEventProbe).counterMetric(GET_QUESTION);
@@ -220,6 +222,7 @@ class QuestionHandlerTest {
 
             verify(mockPersonIdentityService).getPersonIdentityDetailed(kbvItem.getSessionId());
             verify(mockObjectMapper).readValue(kbvItem.getQuestionState(), QuestionState.class);
+            verify(mockConfigurationService).getParameterValue("IIQOperatorId");
             verify(mockEventProbe).counterMetric(GET_QUESTION, 0d);
         }
 
@@ -357,6 +360,7 @@ class QuestionHandlerTest {
             assertEquals(HttpStatusCode.NO_CONTENT, response.getStatusCode());
             assertNull(response.getBody());
             verify(mockEventProbe).counterMetric(GET_QUESTION);
+            verify(mockConfigurationService, times(0)).getParameterValue("IIQOperatorId");
         }
     }
 
@@ -399,6 +403,7 @@ class QuestionHandlerTest {
                     (Map<String, Object>) auditEventMap.getValue().get("experianIiqResponse");
             String outcome = (String) response.get("outcome");
             assertThat(outcome, equalTo(expectedOutcome));
+            verify(mockConfigurationService).getParameterValue("IIQOperatorId");
         }
 
         @Test

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionRequest.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionRequest.java
@@ -7,7 +7,17 @@ public class QuestionRequest {
 
     private String strategy;
 
+    private String iiqOperatorId;
+
     private PersonIdentity personIdentity;
+
+    public String getIiqOperatorId() {
+        return iiqOperatorId;
+    }
+
+    public void setIiqOperatorId(String iiqOperatorId) {
+        this.iiqOperatorId = iiqOperatorId;
+    }
 
     public void setStrategy(String strategy) {
         this.strategy = strategy;

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/StartAuthnAttemptRequestMapper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/StartAuthnAttemptRequestMapper.java
@@ -137,7 +137,8 @@ public class StartAuthnAttemptRequestMapper {
         applicationData.setApplicationType("IG");
         applicationData.setChannel("IN");
         applicationData.setSearchConsent("Y");
-        applicationData.setProduct(StringUtils.isNotBlank(strategy) ? strategy : DEFAULT_STRATEGY);
+        applicationData.setProduct(
+                StringUtils.isNotBlank(strategy) ? strategy : "DEFAULT_STRATEGY");
         saaRequest.setApplicationData(applicationData);
     }
 
@@ -156,7 +157,7 @@ public class StartAuthnAttemptRequestMapper {
                 StringUtils.isNotBlank(questionRequest.getUrn())
                         ? questionRequest.getUrn()
                         : UUID.randomUUID().toString());
-        control.setOperatorID("GDSCABINETUIIQ01U");
+        control.setOperatorID(questionRequest.getIiqOperatorId());
         return control;
     }
 


### PR DESCRIPTION
We currently hardcode the IIQ Operator ID in the java code

We should move this to an SSM parameter on AWS so that it can be configured for any environment

## Proposed changes

### What changed

Added new SSM in `template.yaml` called `IIQOperatorIdParameter`

### Issue tracking

- [KBV-640](https://govukverify.atlassian.net/browse/KBV-640)
