### PR TITLE
KBV-665 Reinstate the KBVApiGatewayId export

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -1150,3 +1150,9 @@ Outputs:
     Value: !If [IsNotDevEnvironment, !Ref PrivateKBVApi, !Ref DevOnlyKBVApi]
     Export:
       Name: !Sub ${AWS::StackName}-PrivateKBVApiGatewayId
+
+  KBVApiGatewayId:
+    Description: "API GatewayID of the KBV CRI API - export currently used by dns-records stack"
+    Value: !Sub "${PublicKBVApi}"
+    Export:
+      Name: !Sub ${AWS::StackName}-KBVApiGatewayId


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Reinstate an output + export as its presently used by the dns-records stack, and is causing an issue in KBV build deploy.