### PR TITLE
BAU: Retrieve secrets at runtime

### DIFF
--- a/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
+++ b/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
@@ -50,19 +50,18 @@ public class QuestionAnswerHandler
     private static final String ERROR_KEY = "error";
     private static final String LAMBDA_NAME = "post_answer";
     private final ObjectMapper objectMapper;
-    private final KBVService kbvService;
-    private final KBVStorageService kbvStorageService;
+    private KBVService kbvService;
+    private KBVStorageService kbvStorageService;
     private final SessionService sessionService;
     private final EventProbe eventProbe;
     private final AuditService auditService;
 
     @ExcludeFromGeneratedCoverageReport
     public QuestionAnswerHandler() {
-        this.objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
         ConfigurationService configurationService = new ConfigurationService();
+        this.objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
         this.kbvStorageService = new KBVStorageService(configurationService);
-        this.kbvService =
-                new KBVService(new KBVGatewayFactory(configurationService).getKbvGateway());
+        this.kbvService = new KBVService(new KBVGatewayFactory().create(configurationService));
         this.eventProbe = new EventProbe();
         this.sessionService = new SessionService();
         this.auditService = new AuditService();

--- a/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
+++ b/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
@@ -32,7 +32,6 @@ import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswerRequest;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionRequest;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionState;
 import uk.gov.di.ipv.cri.kbv.api.exception.QuestionNotFoundException;
-import uk.gov.di.ipv.cri.kbv.api.gateway.KeyStoreLoader;
 import uk.gov.di.ipv.cri.kbv.api.gateway.QuestionsResponse;
 import uk.gov.di.ipv.cri.kbv.api.service.ServiceRegistry;
 
@@ -98,9 +97,8 @@ public class QuestionHandler
     }
 
     private void loadKeyStore() {
-        if (!isLoaded()) {
-            new KeyStoreLoader(this.configurationService).load();
-        }
+        if (!isLoaded()) serviceRegistry.loadKeystore();
+
         setLoaded(true);
     }
 

--- a/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/ServiceRegistry.java
+++ b/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/ServiceRegistry.java
@@ -3,6 +3,7 @@ package uk.gov.di.ipv.cri.kbv.api.service;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.common.library.service.PersonIdentityService;
 import uk.gov.di.ipv.cri.kbv.api.gateway.KBVGatewayFactory;
+import uk.gov.di.ipv.cri.kbv.api.gateway.KeyStoreLoader;
 
 public class ServiceRegistry {
     private final ConfigurationService configurationService;
@@ -17,6 +18,10 @@ public class ServiceRegistry {
 
     public KBVStorageService getKBVStorageService() {
         return new KBVStorageService(this.configurationService);
+    }
+
+    public void loadKeystore() {
+        new KeyStoreLoader(this.configurationService).load();
     }
 
     public PersonIdentityService getPersonIdentityService() {

--- a/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/ServiceRegistry.java
+++ b/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/ServiceRegistry.java
@@ -1,0 +1,25 @@
+package uk.gov.di.ipv.cri.kbv.api.service;
+
+import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
+import uk.gov.di.ipv.cri.common.library.service.PersonIdentityService;
+import uk.gov.di.ipv.cri.kbv.api.gateway.KBVGatewayFactory;
+
+public class ServiceRegistry {
+    private final ConfigurationService configurationService;
+
+    public ServiceRegistry(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+    }
+
+    public KBVService getKBVService() {
+        return new KBVService(new KBVGatewayFactory().create(this.configurationService));
+    }
+
+    public KBVStorageService getKBVStorageService() {
+        return new KBVStorageService(this.configurationService);
+    }
+
+    public PersonIdentityService getPersonIdentityService() {
+        return new PersonIdentityService();
+    }
+}

--- a/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
+++ b/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
@@ -101,10 +101,6 @@ class QuestionHandlerTest {
 
     @Nested
     class QuestionHandlerCalled {
-        @BeforeEach
-        void setUp() {
-            questionHandler.setLoaded(true);
-        }
 
         @Test
         void shouldReturn200OkWhen1stCalledAndReturn1stUnAnsweredQuestionFromExperianEndpoint()

--- a/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
+++ b/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
@@ -107,6 +107,11 @@ class QuestionHandlerTest {
 
     @Nested
     class QuestionHandlerCalled {
+        @BeforeEach
+        void setUp() {
+            questionHandler.setLoaded(true);
+        }
+
         @Test
         void shouldReturn200OkWhen1stCalledAndReturn1stUnAnsweredQuestionFromExperianEndpoint()
                 throws IOException, SqsException {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGatewayFactory.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGatewayFactory.java
@@ -13,7 +13,6 @@ import uk.gov.di.ipv.cri.kbv.api.service.EnvironmentVariablesService;
 import uk.gov.di.ipv.cri.kbv.api.service.MetricsService;
 
 public class KBVGatewayFactory {
-    public static final String IIQ_DATABASE_MODE_PARAM_NAME = "IIQDatabaseMode";
     private final KBVGateway kbvGateway;
 
     public KBVGatewayFactory(ConfigurationService configurationService) {
@@ -21,11 +20,7 @@ public class KBVGatewayFactory {
                 new HeaderHandler(
                         new Base64TokenCacheLoader(
                                 new SoapToken(
-                                        "GDS DI",
-                                        true,
-                                        new TokenService(),
-                                        configurationService.getSecretValue(
-                                                "experian/iiq-wasp-service"))));
+                                        "GDS DI", true, new TokenService(), configurationService)));
 
         new KeyStoreLoader(configurationService).load();
 
@@ -33,16 +28,14 @@ public class KBVGatewayFactory {
         this.kbvGateway =
                 new KBVGateway(
                         new StartAuthnAttemptRequestMapper(
-                                configurationService.getParameterValue(
-                                        IIQ_DATABASE_MODE_PARAM_NAME),
+                                configurationService,
                                 metricsService,
                                 new EnvironmentVariablesService()),
                         new ResponseToQuestionMapper(metricsService),
                         new KBVClientFactory(
                                         new IdentityIQWebService(),
                                         new HeaderHandlerResolver(headerHandler),
-                                        configurationService.getSecretValue(
-                                                "experian/iiq-webservice"))
+                                        configurationService)
                                 .createClient());
     }
 

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/KeyStoreLoader.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/KeyStoreLoader.java
@@ -12,11 +12,11 @@ import java.util.Base64;
 import java.util.Objects;
 import java.util.UUID;
 
-class KeyStoreLoader {
+public class KeyStoreLoader {
     private static final Logger LOGGER = LoggerFactory.getLogger(KeyStoreLoader.class);
     private final ConfigurationService configurationService;
 
-    KeyStoreLoader(ConfigurationService configurationService) {
+    public KeyStoreLoader(ConfigurationService configurationService) {
         this.configurationService =
                 Objects.requireNonNull(
                         configurationService, "configurationService must not be null");
@@ -41,7 +41,7 @@ class KeyStoreLoader {
         return this.configurationService.getSecretValue("experian/keystore-password");
     }
 
-    void load() {
+    public void load() {
         System.setProperty("javax.net.ssl.keyStoreType", "pkcs12");
         System.setProperty("javax.net.ssl.keyStore", getKeyStorePath());
         System.setProperty("javax.net.ssl.keyStorePassword", getPassword());

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/StartAuthnAttemptRequestMapper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/StartAuthnAttemptRequestMapper.java
@@ -18,6 +18,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
+import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionRequest;
 import uk.gov.di.ipv.cri.kbv.api.service.EnvironmentVariablesService;
 import uk.gov.di.ipv.cri.kbv.api.service.MetricsService;
@@ -34,15 +35,18 @@ public class StartAuthnAttemptRequestMapper {
     private static final Logger LOGGER = LogManager.getLogger();
 
     public static final String DEFAULT_TITLE = "MR";
-    private String testDatabase;
+
+    public static final String IIQ_DATABASE_MODE_PARAM_NAME = "IIQDatabaseMode";
+
+    private final ConfigurationService configurationService;
     private MetricsService metricsService;
     private EnvironmentVariablesService environmentVariablesService;
 
     public StartAuthnAttemptRequestMapper(
-            String testDatabase,
+            ConfigurationService configurationService,
             MetricsService metricsService,
             EnvironmentVariablesService environmentVariablesService) {
-        this.testDatabase = testDatabase;
+        this.configurationService = configurationService;
         this.metricsService = metricsService;
         this.environmentVariablesService = environmentVariablesService;
     }
@@ -146,7 +150,8 @@ public class StartAuthnAttemptRequestMapper {
 
     private Control createControl(QuestionRequest questionRequest) {
         Control control = new Control();
-        control.setTestDatabase(testDatabase);
+        control.setTestDatabase(
+                configurationService.getParameterValue(IIQ_DATABASE_MODE_PARAM_NAME));
         Parameters parameters = new Parameters();
         parameters.setOneShotAuthentication("N");
         parameters.setStoreCaseData("P");

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/KBVClientFactory.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/KBVClientFactory.java
@@ -2,21 +2,22 @@ package uk.gov.di.ipv.cri.kbv.api.security;
 
 import com.experian.uk.schema.experian.identityiq.services.webservice.IdentityIQWebService;
 import com.experian.uk.schema.experian.identityiq.services.webservice.IdentityIQWebServiceSoap;
+import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 
 import javax.xml.ws.BindingProvider;
 
 public class KBVClientFactory {
     private final HeaderHandlerResolver headerHandlerResolver;
     private final IdentityIQWebService identityIQWebService;
-    private final String endpointUrl;
+    private final ConfigurationService configurationService;
 
     public KBVClientFactory(
             IdentityIQWebService identityIQWebService,
             HeaderHandlerResolver headerHandlerResolver,
-            String endpointUrl) {
+            ConfigurationService configurationService) {
         this.identityIQWebService = identityIQWebService;
         this.headerHandlerResolver = headerHandlerResolver;
-        this.endpointUrl = endpointUrl;
+        this.configurationService = configurationService;
     }
 
     public IdentityIQWebServiceSoap createClient() {
@@ -27,7 +28,9 @@ public class KBVClientFactory {
 
         ((BindingProvider) identityIQWebServiceSoap)
                 .getRequestContext()
-                .put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, endpointUrl);
+                .put(
+                        BindingProvider.ENDPOINT_ADDRESS_PROPERTY,
+                        configurationService.getSecretValue("experian/iiq-webservice"));
 
         return identityIQWebServiceSoap;
     }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/SoapToken.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/SoapToken.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.cri.kbv.api.security;
 
 import com.experian.uk.wasp.TokenService;
 import com.experian.uk.wasp.TokenServiceSoap;
+import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 
 import javax.xml.ws.BindingProvider;
 
@@ -9,14 +10,17 @@ public class SoapToken {
     private final TokenService tokenService;
     private final String application;
     private final boolean checkIp;
-    private final String endpointUrl;
+    private final ConfigurationService configurationService;
 
     public SoapToken(
-            String application, boolean checkIp, TokenService tokenService, String endpointUrl) {
+            String application,
+            boolean checkIp,
+            TokenService tokenService,
+            ConfigurationService configurationService) {
         this.application = application;
         this.checkIp = checkIp;
         this.tokenService = tokenService;
-        this.endpointUrl = endpointUrl;
+        this.configurationService = configurationService;
     }
 
     public String getToken() {
@@ -25,7 +29,9 @@ public class SoapToken {
         BindingProvider bindingProvider = (BindingProvider) tokenServiceSoap;
         bindingProvider
                 .getRequestContext()
-                .put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, endpointUrl);
+                .put(
+                        BindingProvider.ENDPOINT_ADDRESS_PROPERTY,
+                        configurationService.getSecretValue("experian/iiq-wasp-service"));
 
         return tokenServiceSoap.loginWithCertificate(application, checkIp);
     }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGatewayTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGatewayTest.java
@@ -12,6 +12,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswerRequest;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionRequest;
 import uk.gov.di.ipv.cri.kbv.api.security.HeaderHandler;
@@ -22,6 +23,7 @@ import uk.gov.di.ipv.cri.kbv.api.util.TestDataCreator;
 import javax.xml.ws.soap.SOAPFaultException;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -104,6 +106,8 @@ class KBVGatewayTest {
 
         HeaderHandler headerHandler = mock(HeaderHandler.class);
 
+        ConfigurationService mockConfigurationService = mock(ConfigurationService.class);
+        when(mockConfigurationService.getSecretValue(any())).thenReturn("endpoint");
         KBVGateway kbvGateway =
                 new KBVGateway(
                         mock(StartAuthnAttemptRequestMapper.class),
@@ -111,7 +115,7 @@ class KBVGatewayTest {
                         new KBVClientFactory(
                                         new IdentityIQWebService(),
                                         new HeaderHandlerResolver(headerHandler),
-                                        "endpoint")
+                                        mockConfigurationService)
                                 .createClient());
 
         assertThrows(


### PR DESCRIPTION
Retrieve secrets at runtime this is needed for the [provisioned concurrency work](https://govukverify.atlassian.net/browse/KBV-611)

The secrets would need to be evaluated at run-time, in case of changes to secrets while the application is running