### PR TITLE
KBV-705: make question handler get secrets at runtime

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGatewayFactory.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGatewayFactory.java
@@ -13,40 +13,27 @@ import uk.gov.di.ipv.cri.kbv.api.service.EnvironmentVariablesService;
 import uk.gov.di.ipv.cri.kbv.api.service.MetricsService;
 
 public class KBVGatewayFactory {
-    public static final String IIQ_DATABASE_MODE_PARAM_NAME = "IIQDatabaseMode";
-    private final KBVGateway kbvGateway;
-
-    public KBVGatewayFactory(ConfigurationService configurationService) {
-        HeaderHandler headerHandler =
-                new HeaderHandler(
-                        new Base64TokenCacheLoader(
-                                new SoapToken(
-                                        "GDS DI",
-                                        true,
-                                        new TokenService(),
-                                        configurationService.getSecretValue(
-                                                "experian/iiq-wasp-service"))));
-
+    public KBVGateway create(ConfigurationService configurationService) {
         new KeyStoreLoader(configurationService).load();
-
-        MetricsService metricsService = new MetricsService(new EventProbe());
-        this.kbvGateway =
-                new KBVGateway(
-                        new StartAuthnAttemptRequestMapper(
-                                configurationService.getParameterValue(
-                                        IIQ_DATABASE_MODE_PARAM_NAME),
-                                metricsService,
-                                new EnvironmentVariablesService()),
-                        new ResponseToQuestionMapper(metricsService),
-                        new KBVClientFactory(
-                                        new IdentityIQWebService(),
-                                        new HeaderHandlerResolver(headerHandler),
-                                        configurationService.getSecretValue(
-                                                "experian/iiq-webservice"))
-                                .createClient());
+        return getKbvGateway(configurationService);
     }
 
-    public KBVGateway getKbvGateway() {
-        return this.kbvGateway;
+    private KBVGateway getKbvGateway(ConfigurationService configurationService) {
+        var metricsService = new MetricsService(new EventProbe());
+        return new KBVGateway(
+                new StartAuthnAttemptRequestMapper(
+                        configurationService, metricsService, new EnvironmentVariablesService()),
+                new ResponseToQuestionMapper(metricsService),
+                new KBVClientFactory(
+                                new IdentityIQWebService(),
+                                new HeaderHandlerResolver(getHeaderHandler(configurationService)),
+                                configurationService)
+                        .createClient());
+    }
+
+    private HeaderHandler getHeaderHandler(ConfigurationService configurationService) {
+        return new HeaderHandler(
+                new Base64TokenCacheLoader(
+                        new SoapToken("GDS DI", true, new TokenService(), configurationService)));
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/StartAuthnAttemptRequestMapper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/StartAuthnAttemptRequestMapper.java
@@ -18,6 +18,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
+import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionRequest;
 import uk.gov.di.ipv.cri.kbv.api.service.EnvironmentVariablesService;
 import uk.gov.di.ipv.cri.kbv.api.service.MetricsService;
@@ -34,15 +35,18 @@ public class StartAuthnAttemptRequestMapper {
     private static final Logger LOGGER = LogManager.getLogger();
 
     public static final String DEFAULT_TITLE = "MR";
-    private String testDatabase;
+
+    public static final String IIQ_DATABASE_MODE_PARAM_NAME = "IIQDatabaseMode";
+
+    private final ConfigurationService configurationService;
     private MetricsService metricsService;
     private EnvironmentVariablesService environmentVariablesService;
 
     public StartAuthnAttemptRequestMapper(
-            String testDatabase,
+            ConfigurationService configurationService,
             MetricsService metricsService,
             EnvironmentVariablesService environmentVariablesService) {
-        this.testDatabase = testDatabase;
+        this.configurationService = configurationService;
         this.metricsService = metricsService;
         this.environmentVariablesService = environmentVariablesService;
     }
@@ -146,7 +150,8 @@ public class StartAuthnAttemptRequestMapper {
 
     private Control createControl(QuestionRequest questionRequest) {
         Control control = new Control();
-        control.setTestDatabase(testDatabase);
+        control.setTestDatabase(
+                configurationService.getParameterValue(IIQ_DATABASE_MODE_PARAM_NAME));
         Parameters parameters = new Parameters();
         parameters.setOneShotAuthentication("N");
         parameters.setStoreCaseData("P");

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/KBVClientFactory.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/KBVClientFactory.java
@@ -2,21 +2,22 @@ package uk.gov.di.ipv.cri.kbv.api.security;
 
 import com.experian.uk.schema.experian.identityiq.services.webservice.IdentityIQWebService;
 import com.experian.uk.schema.experian.identityiq.services.webservice.IdentityIQWebServiceSoap;
+import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 
 import javax.xml.ws.BindingProvider;
 
 public class KBVClientFactory {
     private final HeaderHandlerResolver headerHandlerResolver;
     private final IdentityIQWebService identityIQWebService;
-    private final String endpointUrl;
+    private final ConfigurationService configurationService;
 
     public KBVClientFactory(
             IdentityIQWebService identityIQWebService,
             HeaderHandlerResolver headerHandlerResolver,
-            String endpointUrl) {
+            ConfigurationService configurationService) {
         this.identityIQWebService = identityIQWebService;
         this.headerHandlerResolver = headerHandlerResolver;
-        this.endpointUrl = endpointUrl;
+        this.configurationService = configurationService;
     }
 
     public IdentityIQWebServiceSoap createClient() {
@@ -27,7 +28,9 @@ public class KBVClientFactory {
 
         ((BindingProvider) identityIQWebServiceSoap)
                 .getRequestContext()
-                .put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, endpointUrl);
+                .put(
+                        BindingProvider.ENDPOINT_ADDRESS_PROPERTY,
+                        configurationService.getSecretValue("experian/iiq-webservice"));
 
         return identityIQWebServiceSoap;
     }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/SoapToken.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/SoapToken.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.cri.kbv.api.security;
 
 import com.experian.uk.wasp.TokenService;
 import com.experian.uk.wasp.TokenServiceSoap;
+import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 
 import javax.xml.ws.BindingProvider;
 
@@ -9,14 +10,17 @@ public class SoapToken {
     private final TokenService tokenService;
     private final String application;
     private final boolean checkIp;
-    private final String endpointUrl;
+    private final ConfigurationService configurationService;
 
     public SoapToken(
-            String application, boolean checkIp, TokenService tokenService, String endpointUrl) {
+            String application,
+            boolean checkIp,
+            TokenService tokenService,
+            ConfigurationService configurationService) {
         this.application = application;
         this.checkIp = checkIp;
         this.tokenService = tokenService;
-        this.endpointUrl = endpointUrl;
+        this.configurationService = configurationService;
     }
 
     public String getToken() {
@@ -25,7 +29,9 @@ public class SoapToken {
         BindingProvider bindingProvider = (BindingProvider) tokenServiceSoap;
         bindingProvider
                 .getRequestContext()
-                .put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, endpointUrl);
+                .put(
+                        BindingProvider.ENDPOINT_ADDRESS_PROPERTY,
+                        configurationService.getSecretValue("experian/iiq-wasp-service"));
 
         return tokenServiceSoap.loginWithCertificate(application, checkIp);
     }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGatewayTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGatewayTest.java
@@ -12,6 +12,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswerRequest;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionRequest;
 import uk.gov.di.ipv.cri.kbv.api.security.HeaderHandler;
@@ -22,6 +23,7 @@ import uk.gov.di.ipv.cri.kbv.api.util.TestDataCreator;
 import javax.xml.ws.soap.SOAPFaultException;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -104,6 +106,8 @@ class KBVGatewayTest {
 
         HeaderHandler headerHandler = mock(HeaderHandler.class);
 
+        ConfigurationService mockConfigurationService = mock(ConfigurationService.class);
+        when(mockConfigurationService.getSecretValue(any())).thenReturn("endpoint");
         KBVGateway kbvGateway =
                 new KBVGateway(
                         mock(StartAuthnAttemptRequestMapper.class),
@@ -111,7 +115,7 @@ class KBVGatewayTest {
                         new KBVClientFactory(
                                         new IdentityIQWebService(),
                                         new HeaderHandlerResolver(headerHandler),
-                                        "endpoint")
+                                        mockConfigurationService)
                                 .createClient());
 
         assertThrows(


### PR DESCRIPTION
## Proposed changes

By turning on lambda concurrency, the questionHandler lambda would be warm meaning that the configuration values would not be refreshed for running instances. This PR attempt to address this by ensuring config values are used at the point where they are needed and if possible not in the constructor

### What changed

Inject the same configurationService instance into the services

### Why did it change

We need the ability, to refresh configuration at runtime

- [KBV-705:](https://govukverify.atlassian.net/browse/KBV-705:)
