### PR TITLE
BAU Use ARM64 and change memory size per env

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -69,7 +69,9 @@ Globals:
     Runtime: java11
     AutoPublishAlias: live
     Tracing: Active
-    MemorySize: 512
+    MemorySize: !FindInMap [MemorySizeMapping, Environment, !Ref 'Environment']
+    Architectures:
+      - arm64
     Environment:
       Variables:
         JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
@@ -79,6 +81,14 @@ Globals:
         SQS_AUDIT_EVENT_PREFIX: IPV_KBV_CRI
 
 Mappings:
+
+  MemorySizeMapping:
+    Environment:
+      dev: 512
+      build: 1024
+      staging: 1024
+      integration: 1024
+      production: 2048
 
   IIQAPIDatabaseModeMapping:
     Environment:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Use [arm64 for better performance](https://aws.amazon.com/blogs/aws/aws-lambda-functions-powered-by-aws-graviton2-processor-run-your-functions-on-arm-and-get-up-to-34-better-price-performance/), and shift to more memory in higher environments.

Passport CRI has already  done it: https://github.com/alphagov/di-ipv-cri-uk-passport-back/blob/eb04b1a04a98987a5eb88d2d2bc108faf7e89105/deploy/template.yaml#L173-L175

