### PR TITLE
BAU Remove kbv_pass metric, replace with a dimension

### DIFF
--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandler.java
@@ -44,7 +44,7 @@ import static org.apache.logging.log4j.Level.ERROR;
 public class IssueCredentialHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
     public static final String AUTHORIZATION_HEADER_KEY = "Authorization";
-    public static final String KBV_CREDENTIAL_ISSUER = "kbv_credential_issuer";
+    public static final String KBV_CREDENTIAL_ISSUER = "kbv_credentials_issued";
     private final VerifiableCredentialService verifiableCredentialService;
     private final KBVStorageService kbvStorageService;
     private final SessionService sessionService;

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
@@ -31,8 +31,7 @@ import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.*;
 
 public class VerifiableCredentialService {
 
-    public static final String METRIC_KBV_VERIFICATION_SCORE = "kbv_verification_score";
-    public static final String METRIC_KBV_PASS = "kbv_pass";
+    public static final String METRIC_DIMENSION_KBV_VERIFICATION = "kbv_verification";
     private final SignedJWTFactory signedJwtFactory;
     private final ConfigurationService configurationService;
 
@@ -148,11 +147,11 @@ public class VerifiableCredentialService {
 
         if (VC_THIRD_PARTY_KBV_CHECK_PASS.equalsIgnoreCase(kbvItem.getStatus())) {
             evidence.setVerificationScore(VC_PASS_EVIDENCE_SCORE);
-            eventProbe.counterMetric(METRIC_KBV_PASS, 1d);
+            eventProbe.addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
 
         } else {
             evidence.setVerificationScore(VC_FAIL_EVIDENCE_SCORE);
-            eventProbe.counterMetric(METRIC_KBV_PASS, 0d);
+            eventProbe.addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
         }
 
         return new Map[] {objectMapper.convertValue(evidence, Map.class)};


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Remove `kbv_pass` metric, replace with a dimension with the verification pass or fail fact.

We can look up these dimensions on the renamed `kbv_credentials_issued` metric.
