### PR TITLE
Add SecretPrefix parameter to SAM template, with a default value of S…

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -22,6 +22,10 @@ Parameters:
     Description: "The ARN of the permissions boundary to apply when creating IAM roles"
     Type: String
     Default: "none"
+  SecretPrefix:
+    Type: String
+    Default: !Sub ${AWS::StackName}
+    Description: Secrets Manager Prefix
 
 Conditions:
   UseCodeSigningConfigArn:
@@ -76,6 +80,7 @@ Globals:
       Variables:
         JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
         AWS_STACK_NAME: !Sub ${AWS::StackName}
+        SECRET_PREFIX: !Ref SecretPrefix
         POWERTOOLS_LOG_LEVEL: INFO
         POWERTOOLS_METRICS_NAMESPACE: di-ipv-cri-kbv-api
         SQS_AUDIT_EVENT_PREFIX: IPV_KBV_CRI
@@ -564,7 +569,7 @@ Resources:
               Effect: Allow
               Action:
                 - 'secretsmanager:GetSecretValue'
-              Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${AWS::StackName}/experian*'
+              Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${SecretPrefix}/experian*'
         - Statement:
             - Effect: Allow
               Action:
@@ -628,7 +633,7 @@ Resources:
               Effect: Allow
               Action:
                 - 'secretsmanager:GetSecretValue'
-              Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${AWS::StackName}/experian*'
+              Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${SecretPrefix}/experian*'
         - Statement:
             - Effect: Allow
               Action:

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -24,8 +24,8 @@ Parameters:
     Default: "none"
   SecretPrefix:
     Type: String
-    Default: !Sub ${AWS::StackName}
-    Description: Secrets Manager Prefix
+    Default: "none"
+    Description: Secrets name prefix
 
 Conditions:
   UseCodeSigningConfigArn:
@@ -55,6 +55,12 @@ Conditions:
       - Fn::Equals:
           - !Ref PermissionsBoundary
           - "none"
+  UseSecretPrefix:
+    Fn::Not:
+      - Fn::Equals:
+        - !Ref SecretPrefix
+        - "none"
+
 Globals:
   Function:
     VpcConfig:
@@ -69,6 +75,7 @@ Globals:
       - UseCodeSigningConfigArn
       - !Ref CodeSigningConfigArn
       - !Ref AWS::NoValue
+
     Timeout: 30 # seconds
     Runtime: java11
     AutoPublishAlias: live
@@ -80,7 +87,7 @@ Globals:
       Variables:
         JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
         AWS_STACK_NAME: !Sub ${AWS::StackName}
-        SECRET_PREFIX: !Ref SecretPrefix
+        SECRET_PREFIX: !If [UseSecretPrefix, !Ref SecretPrefix , !Ref AWS::StackName]
         POWERTOOLS_LOG_LEVEL: INFO
         POWERTOOLS_METRICS_NAMESPACE: di-ipv-cri-kbv-api
         SQS_AUDIT_EVENT_PREFIX: IPV_KBV_CRI
@@ -569,7 +576,9 @@ Resources:
               Effect: Allow
               Action:
                 - 'secretsmanager:GetSecretValue'
-              Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${SecretPrefix}/experian*'
+              Resource: !Sub
+                - 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${Prefix}/experian*'
+                - Prefix: !If [UseSecretPrefix, !Ref SecretPrefix , !Ref AWS::StackName]
         - Statement:
             - Effect: Allow
               Action:
@@ -633,7 +642,9 @@ Resources:
               Effect: Allow
               Action:
                 - 'secretsmanager:GetSecretValue'
-              Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${SecretPrefix}/experian*'
+              Resource: !Sub
+                - 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${Prefix}/experian*'
+                - Prefix: !If [UseSecretPrefix, !Ref SecretPrefix , !Ref AWS::StackName]
         - Statement:
             - Effect: Allow
               Action:


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Add SecretPrefix parameter to SAM template, with a default value of Stack Name

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

We want to read secrets in secrets manager that have a default name across dev stacks, so that we don’t have to set secrets per stack.

Also see https://github.com/alphagov/di-ipv-cri-lib/pull/40

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-795](https://govukverify.atlassian.net/browse/KBV-795)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks