### PR TITLE
KBV-774: Capture duration of experian requests

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGateway.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGateway.java
@@ -19,12 +19,16 @@ import uk.gov.di.ipv.cri.kbv.api.domain.QuestionRequest;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionsResponse;
 import uk.gov.di.ipv.cri.kbv.api.service.MetricsService;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 
 public class KBVGateway {
     private static final String EXPERIAN_IIQ_REQUEST = "experian_iiq_request_type";
     private static final Logger LOGGER = LogManager.getLogger();
+    private static final String EXPERIAN_START_AUTHENTICATION_ATTEMPT = "saa";
+    private static final String EXPERIAN_RESPONSE_TO_QUESTIONS = "rtq";
 
     private final StartAuthnAttemptRequestMapper saaRequestMapper;
     private final ResponseToQuestionMapper responseToQuestionMapper;
@@ -55,9 +59,14 @@ public class KBVGateway {
 
     @Tracing
     public QuestionsResponse getQuestions(QuestionRequest questionRequest) {
-        TracingUtils.putAnnotation(EXPERIAN_IIQ_REQUEST, "saa");
+        TracingUtils.putAnnotation(EXPERIAN_IIQ_REQUEST, EXPERIAN_START_AUTHENTICATION_ATTEMPT);
         SAARequest saaRequest = saaRequestMapper.mapQuestionRequest(questionRequest);
+
+        Instant start = Instant.now();
         SAAResponse2 saaResponse2 = identityIQWebServiceSoap.saa(saaRequest);
+        Instant end = Instant.now();
+        logTimeTaken(start, end, EXPERIAN_START_AUTHENTICATION_ATTEMPT);
+
         QuestionsResponse questionsResponse = questionsResponseMapper.mapSAAResponse(saaResponse2);
 
         if (questionsResponse.hasError()) {
@@ -78,10 +87,14 @@ public class KBVGateway {
 
     @Tracing
     public QuestionsResponse submitAnswers(QuestionAnswerRequest questionAnswerRequest) {
-        TracingUtils.putAnnotation(EXPERIAN_IIQ_REQUEST, "rtq");
+        TracingUtils.putAnnotation(EXPERIAN_IIQ_REQUEST, EXPERIAN_RESPONSE_TO_QUESTIONS);
         RTQRequest rtqRequest =
                 responseToQuestionMapper.mapQuestionAnswersRtqRequest(questionAnswerRequest);
+
+        Instant start = Instant.now();
         RTQResponse2 rtqResponse2 = identityIQWebServiceSoap.rtq(rtqRequest);
+        Instant end = Instant.now();
+        logTimeTaken(start, end, EXPERIAN_RESPONSE_TO_QUESTIONS);
 
         QuestionsResponse questionsResponse = questionsResponseMapper.mapRTQResponse(rtqResponse2);
 
@@ -95,6 +108,17 @@ public class KBVGateway {
         sendResultMetric("submit_questions_response", questionsResponse.getResults());
 
         return questionsResponse;
+    }
+
+    private void logTimeTaken(Instant start, Instant end, String requestType) {
+        long timeTaken = Duration.between(start, end).toMillis();
+        this.metricsService.sendTimeTakenMetric(
+                String.valueOf(timeTaken), EXPERIAN_IIQ_REQUEST + "_" + requestType);
+        LOGGER.info(
+                "Experian Response - Time taken for {} of value: {} is: {}",
+                EXPERIAN_IIQ_REQUEST,
+                requestType,
+                timeTaken);
     }
 
     private void logError(String context, QuestionsResponse questionsResponse) {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGateway.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGateway.java
@@ -63,7 +63,7 @@ public class KBVGateway {
         SAARequest saaRequest = saaRequestMapper.mapQuestionRequest(questionRequest);
 
         Instant start = Instant.now();
-        SAAResponse2 saaResponse2 = identityIQWebServiceSoap.saa(saaRequest);
+        SAAResponse2 saaResponse2 = getQuestionRequestResponse(saaRequest);
         Instant end = Instant.now();
         logTimeTaken(start, end, EXPERIAN_START_AUTHENTICATION_ATTEMPT);
 
@@ -92,7 +92,7 @@ public class KBVGateway {
                 responseToQuestionMapper.mapQuestionAnswersRtqRequest(questionAnswerRequest);
 
         Instant start = Instant.now();
-        RTQResponse2 rtqResponse2 = identityIQWebServiceSoap.rtq(rtqRequest);
+        RTQResponse2 rtqResponse2 = submitQuestionAnswerResponse(rtqRequest);
         Instant end = Instant.now();
         logTimeTaken(start, end, EXPERIAN_RESPONSE_TO_QUESTIONS);
 
@@ -108,6 +108,16 @@ public class KBVGateway {
         sendResultMetric("submit_questions_response", questionsResponse.getResults());
 
         return questionsResponse;
+    }
+
+    @Tracing(segmentName = "getQuestionResponse")
+    private SAAResponse2 getQuestionRequestResponse(SAARequest saaRequest) {
+        return identityIQWebServiceSoap.saa(saaRequest);
+    }
+
+    @Tracing(segmentName = "submitQuestionAnswerResponse")
+    private RTQResponse2 submitQuestionAnswerResponse(RTQRequest rtqRequest) {
+        return identityIQWebServiceSoap.rtq(rtqRequest);
     }
 
     private void logTimeTaken(Instant start, Instant end, String requestType) {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/StartAuthnAttemptRequestMapper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/StartAuthnAttemptRequestMapper.java
@@ -22,7 +22,6 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 class StartAuthnAttemptRequestMapper {
-
     private static final String DEFAULT_TITLE = "MR";
     private static final String IIQ_DATABASE_MODE_PARAM_NAME = "IIQDatabaseMode";
 

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/MetricsService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/MetricsService.java
@@ -12,7 +12,7 @@ public class MetricsService {
     public static final String OUTCOME = "outcome";
     public static final String TRANS_ID = "transition_id";
     public static final String ERROR_CODE = "error_code";
-    static final String TIME_TAKEN = "time_taken";
+    public static final String EXECUTION_DURATION = "execution_duration";
     private final EventProbe eventProbe;
 
     public MetricsService(EventProbe eventProbe) {
@@ -26,21 +26,21 @@ public class MetricsService {
         }
     }
 
-    public void sendTimeTakenMetric(String timeTaken, String metricName) {
-        if (StringUtils.isNotBlank(timeTaken)) {
-            eventProbe.addDimensions(Map.of(TIME_TAKEN, timeTaken));
-            eventProbe.counterMetric(metricName);
-        }
-    }
-
-    public void sendResultMetric(KbvResult result, String metricName) {
+    public void sendResultMetric(KbvResult result, String metricName, long executionDuration) {
         if (Objects.nonNull(result)) {
             String transIds = "";
             if (Objects.nonNull(result.getNextTransId()) && result.getNextTransId().length > 0) {
                 transIds = String.join(",", result.getNextTransId());
             }
             if (StringUtils.isNotBlank(result.getOutcome())) {
-                eventProbe.addDimensions(Map.of(OUTCOME, result.getOutcome(), TRANS_ID, transIds));
+                eventProbe.addDimensions(
+                        Map.of(
+                                OUTCOME,
+                                result.getOutcome(),
+                                TRANS_ID,
+                                transIds,
+                                EXECUTION_DURATION,
+                                String.valueOf(executionDuration)));
                 eventProbe.counterMetric(metricName);
             }
         }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/MetricsService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/MetricsService.java
@@ -12,6 +12,7 @@ public class MetricsService {
     public static final String OUTCOME = "outcome";
     public static final String TRANS_ID = "transition_id";
     public static final String ERROR_CODE = "error_code";
+    static final String TIME_TAKEN = "time_taken";
     private final EventProbe eventProbe;
 
     public MetricsService(EventProbe eventProbe) {
@@ -21,6 +22,13 @@ public class MetricsService {
     public void sendErrorMetric(String errorCode, String metricName) {
         if (StringUtils.isNotBlank(errorCode)) {
             eventProbe.addDimensions(Map.of(ERROR_CODE, errorCode));
+            eventProbe.counterMetric(metricName);
+        }
+    }
+
+    public void sendTimeTakenMetric(String timeTaken, String metricName) {
+        if (StringUtils.isNotBlank(timeTaken)) {
+            eventProbe.addDimensions(Map.of(TIME_TAKEN, timeTaken));
             eventProbe.counterMetric(metricName);
         }
     }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGatewayTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGatewayTest.java
@@ -17,6 +17,8 @@ import uk.gov.di.ipv.cri.kbv.api.domain.QuestionsResponse;
 import uk.gov.di.ipv.cri.kbv.api.service.MetricsService;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -49,7 +51,8 @@ class KBVGatewayTest {
         verify(mockSAARequestMapper).mapQuestionRequest(questionRequest);
         verify(mockIdentityIQWebServiceSoap).saa(mockSaaRequest);
         verify(mockQuestionsResponseMapper).mapSAAResponse(mockSaaResponse);
-        verify(mockMetricsService).sendResultMetric(mockKbvResult, "initial_questions_response");
+        verify(mockMetricsService)
+                .sendResultMetric(eq(mockKbvResult), eq("initial_questions_response"), anyLong());
     }
 
     @Test
@@ -71,7 +74,8 @@ class KBVGatewayTest {
         verify(mockResponseToQuestionMapper).mapQuestionAnswersRtqRequest(questionAnswerRequest);
         verify(mockIdentityIQWebServiceSoap).rtq(mockRtqRequest);
         verify(mockQuestionsResponseMapper).mapRTQResponse(mockRtqResponse);
-        verify(mockMetricsService).sendResultMetric(mockKbvResult, "submit_questions_response");
+        verify(mockMetricsService)
+                .sendResultMetric(eq(mockKbvResult), eq("submit_questions_response"), anyLong());
     }
 
     @Test

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/MetricsServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/MetricsServiceTest.java
@@ -12,8 +12,8 @@ import java.util.Map;
 
 import static org.mockito.Mockito.verify;
 import static uk.gov.di.ipv.cri.kbv.api.service.MetricsService.ERROR_CODE;
+import static uk.gov.di.ipv.cri.kbv.api.service.MetricsService.EXECUTION_DURATION;
 import static uk.gov.di.ipv.cri.kbv.api.service.MetricsService.OUTCOME;
-import static uk.gov.di.ipv.cri.kbv.api.service.MetricsService.TIME_TAKEN;
 import static uk.gov.di.ipv.cri.kbv.api.service.MetricsService.TRANS_ID;
 
 @ExtendWith(MockitoExtension.class)
@@ -27,14 +27,23 @@ class MetricsServiceTest {
     void shouldSendResultsMetric() {
         String resultOutcome = "outcome";
         String resultTransId = "transId";
+        long executionDuration = 7500l;
         KbvResult kbvResult = new KbvResult();
         kbvResult.setOutcome(resultOutcome);
         kbvResult.setNextTransId(new String[] {resultTransId});
 
-        this.metricsService.sendResultMetric(kbvResult, "baz");
+        this.metricsService.sendResultMetric(kbvResult, "baz", executionDuration);
 
         verify(eventProbe).counterMetric("baz");
-        verify(eventProbe).addDimensions(Map.of(OUTCOME, resultOutcome, TRANS_ID, resultTransId));
+        verify(eventProbe)
+                .addDimensions(
+                        Map.of(
+                                OUTCOME,
+                                resultOutcome,
+                                TRANS_ID,
+                                resultTransId,
+                                EXECUTION_DURATION,
+                                String.valueOf(executionDuration)));
     }
 
     @Test
@@ -43,13 +52,5 @@ class MetricsServiceTest {
         this.metricsService.sendErrorMetric(errorCode, "baz");
         verify(eventProbe).counterMetric("baz");
         verify(eventProbe).addDimensions(Map.of(ERROR_CODE, errorCode));
-    }
-
-    @Test
-    void shouldSendTimeTakenMetric() {
-        String timeTaken = "time-taken";
-        this.metricsService.sendTimeTakenMetric(timeTaken, "some request time taken");
-        verify(eventProbe).counterMetric("some request time taken");
-        verify(eventProbe).addDimensions(Map.of(TIME_TAKEN, timeTaken));
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/MetricsServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/MetricsServiceTest.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import static org.mockito.Mockito.verify;
 import static uk.gov.di.ipv.cri.kbv.api.service.MetricsService.ERROR_CODE;
 import static uk.gov.di.ipv.cri.kbv.api.service.MetricsService.OUTCOME;
+import static uk.gov.di.ipv.cri.kbv.api.service.MetricsService.TIME_TAKEN;
 import static uk.gov.di.ipv.cri.kbv.api.service.MetricsService.TRANS_ID;
 
 @ExtendWith(MockitoExtension.class)
@@ -42,5 +43,13 @@ class MetricsServiceTest {
         this.metricsService.sendErrorMetric(errorCode, "baz");
         verify(eventProbe).counterMetric("baz");
         verify(eventProbe).addDimensions(Map.of(ERROR_CODE, errorCode));
+    }
+
+    @Test
+    void shouldSendTimeTakenMetric() {
+        String timeTaken = "time-taken";
+        this.metricsService.sendTimeTakenMetric(timeTaken, "some request time taken");
+        verify(eventProbe).counterMetric("some request time taken");
+        verify(eventProbe).addDimensions(Map.of(TIME_TAKEN, timeTaken));
     }
 }


### PR DESCRIPTION
## Proposed changes

Even though X-ray provides subsegments that show the actual duration of the request being investigated. There isn't an easy way to extract this information. This PR is needed to be able to capture the actual duration of the experian requests i.e. the request for question and the duration of the request when submitting answers

see: https://govukverify.atlassian.net/browse/KBV-774


### What changed

Add more metric and logging for experian requests

### Why did it change

More information required to the extract details at the level of the method call

### Other considerations
It maybe that just logging would be enough, however added metric here as well if it proves not be useful would remove in future PR

