### PR TITLE
BAU: Add X-Forwarded-For header to api definition

### DIFF
--- a/infrastructure/lambda/private-api.yaml
+++ b/infrastructure/lambda/private-api.yaml
@@ -38,6 +38,14 @@ paths:
 
   /session:
     post:
+      summary: IP address of the client.
+      parameters:
+        - in: header
+          name: X-Forwarded-For
+          schema:
+            type: string
+            format: uuid
+          required: true
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
## Proposed changes

Added open-api validation for X-Forwarded-For header

### What changed

See https://github.com/alphagov/di-ipv-cri-lib/pull/35

### Why did it change

Needed for AuditService
