### PR TITLE
OJ-801 Update code signing config for dev environments

### DIFF
--- a/.github/workflows/pre-merge-integration-test.yml
+++ b/.github/workflows/pre-merge-integration-test.yml
@@ -57,7 +57,7 @@ jobs:
           sam deploy -t infrastructure/lambda/template.yaml \
             --no-fail-on-empty-changeset \
             --no-confirm-changeset \
-            --parameter-overrides Environment=${{ env.ENVIRONMENT }} \
+            --parameter-overrides "Environment=${{ env.ENVIRONMENT }} CodeSigningEnabled=false" \
             --stack-name $STACK_NAME \
             --s3-bucket ${{ secrets.AWS_CONFIG_BUCKET }} \
             --s3-prefix $STACK_NAME \

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -3,6 +3,9 @@ Transform: "AWS::Serverless-2016-10-31"
 Description: "Digital Identity IPV CRI KBV API"
 
 Parameters:
+  CodeSigningEnabled:
+    Type: "String"
+    Default: "true"
   CodeSigningConfigArn:
     Type: String
     Default: "none"
@@ -28,6 +31,9 @@ Parameters:
     Description: Secrets name prefix
 
 Conditions:
+  EnforceCodeSigning: !Equals
+    - !Ref  CodeSigningEnabled
+    - true
   UseCodeSigningConfigArn:
     Fn::Not:
       - Fn::Equals:
@@ -72,10 +78,9 @@ Globals:
       - !Ref PermissionsBoundary
       - !Ref AWS::NoValue
     CodeSigningConfigArn: !If
-      - UseCodeSigningConfigArn
+      - EnforceCodeSigning
       - !Ref CodeSigningConfigArn
       - !Ref AWS::NoValue
-
     Timeout: 30 # seconds
     Runtime: java11
     AutoPublishAlias: live


### PR DESCRIPTION
## Proposed changes

### What changed

The sam template and GH pre-merge integration test workflow have been updated.

### Why did it change

The code signing has been enforced in the secure pipelines for the new dev environments but optional opt out for the pre-merge integration tests and to allow developers to push.


### Issue tracking

- [OJ-801](https://govukverify.atlassian.net/browse/OJ-801)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

Changes made as previously rolled out for address