### PR TITLE
OJ-822 restore log groups

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -458,11 +458,13 @@ Resources:
               Resource:
                 - !ImportValue AuditEventQueueEncryptionKeyArn
 
-  SessionFunctionLogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName: !Sub "/aws/lambdalg/${SessionFunction}"
-      RetentionInDays: 14
+# Will need to enable and import at later date to overcome clean deployment issues
+#  SessionFunctionLogGroup:
+#    Type: AWS::Logs::LogGroup
+#    DeletionPolicy: "Retain"
+#    Properties:
+#      LogGroupName: !Sub "/aws/lambda/${SessionFunction}"
+#      RetentionInDays: 14
 
   SessionFunctionLogGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
@@ -470,7 +472,7 @@ Resources:
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
-      LogGroupName: !Ref SessionFunctionLogGroup
+      LogGroupName: !Sub "/aws/lambda/${SessionFunction}"
 
   AuthorizationFunction:
     Type: AWS::Serverless::Function
@@ -498,11 +500,13 @@ Resources:
               Resource:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/clients/*"
 
-  AuthorizationFunctionLogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName: !Sub "/aws/lambdalg/${AuthorizationFunction}"
-      RetentionInDays: 14
+  # Will need to enable and import at later date to overcome clean deployment issues
+#  AuthorizationFunctionLogGroup:
+#    Type: AWS::Logs::LogGroup
+#    DeletionPolicy: "Retain"
+#    Properties:
+#      LogGroupName: !Sub "/aws/lambda/${AuthorizationFunction}"
+#      RetentionInDays: 14
 
   AuthorizationFunctionLogGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
@@ -510,7 +514,7 @@ Resources:
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
-      LogGroupName: !Ref AuthorizationFunctionLogGroup
+      LogGroupName: !Sub "/aws/lambda/${AuthorizationFunction}"
 
   AccessTokenFunction:
     Type: AWS::Serverless::Function
@@ -541,11 +545,13 @@ Resources:
               Resource:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/clients/*"
 
-  AccessTokenFunctionLogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName: !Sub "/aws/lambdalg/${AccessTokenFunction}"
-      RetentionInDays: 14
+# Will need to enable and import at later date to overcome clean deployment issues
+#  AccessTokenFunctionLogGroup:
+#    Type: AWS::Logs::LogGroup
+#    DeletionPolicy: "Retain"
+#    Properties:
+#      LogGroupName: !Sub "/aws/lambda/${AccessTokenFunction}"
+#      RetentionInDays: 14
 
   AccessTokenFunctionLogGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
@@ -553,7 +559,7 @@ Resources:
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
-      LogGroupName: !Ref AccessTokenFunctionLogGroup
+      LogGroupName: !Sub "/aws/lambda/${AccessTokenFunction}"
 
   KBVQuestionFunction:
     Type: AWS::Serverless::Function
@@ -617,11 +623,13 @@ Resources:
               Resource:
                 - !ImportValue AuditEventQueueEncryptionKeyArn
 
-  KBVQuestionFunctionLogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName: !Sub "/aws/lambdalg/${KBVQuestionFunction}"
-      RetentionInDays: 14
+# Will need to enable and import at later date to overcome clean deployment issues
+#  KBVQuestionFunctionLogGroup:
+#    Type: AWS::Logs::LogGroup
+#    DeletionPolicy: "Retain"
+#    Properties:
+#      LogGroupName: !Sub "/aws/lambda/${KBVQuestionFunction}"
+#      RetentionInDays: 14
 
   KBVQuestionFunctionLogGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
@@ -629,7 +637,7 @@ Resources:
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
-      LogGroupName: !Ref KBVQuestionFunctionLogGroup
+      LogGroupName: !Sub "/aws/lambda/${KBVQuestionFunction}"
 
   KBVAnswerFunction:
     Type: AWS::Serverless::Function
@@ -689,11 +697,13 @@ Resources:
               Resource:
                 - !ImportValue AuditEventQueueEncryptionKeyArn
 
-  KBVAnswerFunctionLogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName: !Sub "/aws/lambdalg/${KBVAnswerFunction}"
-      RetentionInDays: 14
+# Will need to enable and import at later date to overcome clean deployment issues
+#  KBVAnswerFunctionLogGroup:
+#    Type: AWS::Logs::LogGroup
+#    DeletionPolicy: "Retain"
+#    Properties:
+#      LogGroupName: !Sub "/aws/lambda/${KBVAnswerFunction}"
+#      RetentionInDays: 14
 
   KBVAnswerFunctionLogGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
@@ -701,7 +711,7 @@ Resources:
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
-      LogGroupName: !Ref KBVAnswerFunctionLogGroup
+      LogGroupName: !Sub "/aws/lambda/${KBVAnswerFunction}"
 
   KBVAbandonFunction:
     Type: AWS::Serverless::Function
@@ -730,11 +740,13 @@ Resources:
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/KBVTableName"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/SessionTableName"
 
-  KBVAbandonFunctionLogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName: !Sub "/aws/lambdalg/${KBVAbandonFunction}"
-      RetentionInDays: 14
+# Will need to enable and import at later date to overcome clean deployment issues
+#  KBVAbandonFunctionLogGroup:
+#    Type: AWS::Logs::LogGroup
+#    DeletionPolicy: "Retain"
+#    Properties:
+#      LogGroupName: !Sub "/aws/lambda/${KBVAbandonFunction}"
+#      RetentionInDays: 14
 
   KBVAbandonFunctionLogGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
@@ -742,7 +754,7 @@ Resources:
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
-      LogGroupName: !Ref KBVAbandonFunctionLogGroup
+      LogGroupName: !Sub "/aws/lambda/${KBVAbandonFunction}"
 
   IssueCredentialFunction:
     Type: AWS::Serverless::Function
@@ -779,11 +791,13 @@ Resources:
             Resource:
               - !ImportValue AuditEventQueueEncryptionKeyArn
 
-  IssueCredentialFunctionLogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName: !Sub "/aws/lambdalg/${IssueCredentialFunction}"
-      RetentionInDays: 14
+# Will need to enable and import at later date to overcome clean deployment issues
+#  IssueCredentialFunctionLogGroup:
+#    Type: AWS::Logs::LogGroup
+#    DeletionPolicy: "Retain"
+#    Properties:
+#      LogGroupName: !Sub "/aws/lambda/${IssueCredentialFunction}"
+#      RetentionInDays: 14
 
   IssueCredentialFunctionLogGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
@@ -791,7 +805,7 @@ Resources:
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
-      LogGroupName: !Ref IssueCredentialFunctionLogGroup
+      LogGroupName: !Sub "/aws/lambda/${IssueCredentialFunction}"
 
   KBVTable:
     Type: "AWS::DynamoDB::Table"


### PR DESCRIPTION
## Proposed changes

### What changed

Restore previous log groups configuration

### Why did it change

Log groups configuration was not fully configured and logs written to old groups so temporarily restore old groups to ship logs to splunk. New updated log groups need to be enabled for deployment to a clean account but for existing accounts will need importing. 

### Issue tracking

- [OJ-822](https://govukverify.atlassian.net/browse/OJ-822)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

Commented blocks left in which will need importing at a later date

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks