### PR TITLE
OJ-953 - add private api-gateway ssm parameter

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -1179,7 +1179,13 @@ Resources:
       Value: !Sub "https://${PublicKBVApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/"
       Description: "Base url of the public KBV CRI API"
 
-
+  PrivateKBVApiGatewayIdParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/PrivateKBVApiGatewayId"
+      Type: String
+      Value: !If [IsNotDevEnvironment, !Ref PrivateKBVApi, !Ref DevOnlyKBVApi]
+      Description: "API GatewayID of the private KBV CRI API"
 
   SessionFunctionPermission:
     Type: AWS::Lambda::Permission


### PR DESCRIPTION
### What changed
- Added an SSM parameter for the private api gateway id

### Why did it change
- To remove the tight-coupling between the kbv-api stack and the dns-records/kbv-front stacks

### Issue tracking
- [OJ-953](https://govukverify.atlassian.net/browse/OJ-953)
