### PR TITLE
Revert "OJ-953 - add private api-gateway ssm parameter"

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -1179,13 +1179,7 @@ Resources:
       Value: !Sub "https://${PublicKBVApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/"
       Description: "Base url of the public KBV CRI API"
 
-  PrivateKBVApiGatewayIdParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub "/${AWS::StackName}/PrivateKBVApiGatewayId"
-      Type: String
-      Value: !If [IsNotDevEnvironment, !Ref PrivateKBVApi, !Ref DevOnlyKBVApi]
-      Description: "API GatewayID of the private KBV CRI API"
+
 
   SessionFunctionPermission:
     Type: AWS::Lambda::Permission


### PR DESCRIPTION
Reverts alphagov/di-ipv-cri-kbv-api#173
After careful consideration, it has transpired that this change is no longer necessary.
The path to live for the new stack will now rely on the existing Export/ImportValue approach.