### PR TITLE
feat: OJ-541 alert on lambda and APIGW errors and notify to email

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -115,7 +115,7 @@
         "filename": ".github/workflows/pre-merge-integration-test.yml",
         "hashed_secret": "4b0b79e641eb2908e8e42cb32013ce4d60348413",
         "is_verified": false,
-        "line_number": 23
+        "line_number": 20
       }
     ],
     "infrastructure/lambda/public-api.yaml": [
@@ -124,51 +124,23 @@
         "filename": "infrastructure/lambda/public-api.yaml",
         "hashed_secret": "01613fb1bb441c88d5e6773e2813ee026ad5b928",
         "is_verified": false,
-        "line_number": 35
+        "line_number": 34
       },
       {
         "type": "JSON Web Token",
         "filename": "infrastructure/lambda/public-api.yaml",
         "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
         "is_verified": false,
-        "line_number": 100
+        "line_number": 98
       }
     ],
     "infrastructure/lambda/template.yaml": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "infrastructure/lambda/template.yaml",
-        "hashed_secret": "407b058c0f67be53116117c4b021b5e95f9dca9e",
-        "is_verified": false,
-        "line_number": 186
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "infrastructure/lambda/template.yaml",
-        "hashed_secret": "486b0e17dde4271451ce7c815378fab9081085d1",
-        "is_verified": false,
-        "line_number": 197
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "infrastructure/lambda/template.yaml",
-        "hashed_secret": "81249afd017322b40765e849988f74ebc18e757c",
-        "is_verified": false,
-        "line_number": 198
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "infrastructure/lambda/template.yaml",
-        "hashed_secret": "54ec3197768e4b02c47ff91d4858f80b0c6fad30",
-        "is_verified": false,
-        "line_number": 199
-      },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 610
+        "line_number": 389
       }
     ],
     "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/fixtures/TestFixtures.java": [
@@ -227,5 +199,5 @@
       }
     ]
   },
-  "generated_at": "2022-09-20T14:28:05Z"
+  "generated_at": "2022-10-01T15:56:37Z"
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# di-ipv-cri-kbv-api
-IPV Knowledge Based Verification Credential Issuer
+# IPV Knowledge Based Verification Credential Issuer
 
 ## Hooks
 
@@ -31,6 +30,18 @@ cd into each submodule (folders are `/lib` and `/common-lambdas`) and run the fo
 Build with `./gradlew`
 
 This will run "build", "test", "buildZip", and "spotLess" reformatting
+
+## Deploy to dev environment
+
+Ensure you have the `sam-cli` and `gds-cli` installed, and that you can assume an admin role on the `di-ipv-cri-dev` AWS account.
+
+
+Copy `infrastructure/lambda/samconfig.toml.example` to `infrastructure/lambda/samconfig.toml`, and change the stack name in the new file.
+
+Deploy to the dev environment with:
+
+`gds aws di-ipv-cri-dev -- ./deploy.sh`
+
 
 ## Deploy to AWS lambda
 
@@ -65,3 +76,8 @@ Deployment to Build:
 | BUILD_SIGNING_PROFILE_NAME        | The AWS signer signing profile name                   |
 | BUILD_GH_ACTIONS_ROLE_ARN         | Assumed role IAM ARN                                  |
 
+## Required SSM Parameters
+
+| Parameter                  | Description                      |
+|----------------------------|----------------------------------|
+| `/alerting/email-address`  | email address to receive alerts  |

--- a/infrastructure/lambda/samconfig.toml.example
+++ b/infrastructure/lambda/samconfig.toml.example
@@ -1,0 +1,12 @@
+version = 0.1
+[dev]
+[dev.deploy]
+[dev.deploy.parameters]
+stack_name = "kbv-example"
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-1bcgk7c5b2imd"
+s3_prefix = "kbv-example"
+region = "eu-west-2"
+capabilities = "CAPABILITY_IAM"
+disable_rollback = true
+parameter_overrides = "CodeSigningConfigArn=\"none\" Environment=\"dev\" PermissionsBoundary=\"none\" SecretPrefix=\"none\", CodeSigningEnabled=\"false\", CommonStackName=\"kbv-common-cri-api\", SecretPrefix=\"kbv-cri-api\""
+image_repositories = []

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -805,6 +805,126 @@ Resources:
             Condition:
               ArnLike:
                 "kms:EncryptionContext:aws:logs:arn": !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+
+  AlarmLambdaErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsNotDevEnvironment
+    Properties:
+      AlarmName: !Sub "${Environment}-${AWS::StackName}-lambda"
+      AlarmDescription: !Sub "${Environment} lambda errors"
+      ActionsEnabled: true
+      OKActions:
+        - !Ref AlarmTopic
+      AlarmActions:
+        - !Ref AlarmTopic
+      InsufficientDataActions: []
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Dimensions: []
+      Period: 60
+      EvaluationPeriods: 2
+      DatapointsToAlarm: 2
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  AlarmAPIGW5XXErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsNotDevEnvironment
+    Properties:
+      AlarmName: !Sub "${Environment}-${AWS::StackName}-APIGW5XX"
+      AlarmDescription: !Sub "${Environment} API Gateway 5XX errors"
+      ActionsEnabled: true
+      OKActions:
+        - !Ref AlarmTopic
+      AlarmActions:
+        - !Ref AlarmTopic
+      InsufficientDataActions: []
+      Dimensions: []
+      EvaluationPeriods: 2
+      DatapointsToAlarm: 2
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: e1
+          Label: Expression1
+          ReturnData: true
+          Expression: SUM(METRICS())
+        - Id: m1
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: 5XXError
+              Dimensions:
+                - Name: Stage
+                  Value: !Ref Environment
+            Period: 60
+            Stat: Sum
+
+  AlarmAPIGW4XXErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsNotDevEnvironment
+    Properties:
+      AlarmName: !Sub "${Environment}-${AWS::StackName}-APIGW4XX"
+      AlarmDescription: !Sub "${Environment} API Gateway 4XX errors"
+      ActionsEnabled: true
+      OKActions:
+        - !Ref AlarmTopic
+      AlarmActions:
+        - !Ref AlarmTopic
+      InsufficientDataActions: []
+      Dimensions: []
+      EvaluationPeriods: 2
+      DatapointsToAlarm: 2
+      Threshold: 2
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: e1
+          Label: Expression1
+          ReturnData: true
+          Expression: SUM(METRICS())
+        - Id: m1
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: 4XXError
+              Dimensions:
+                - Name: Stage
+                  Value: !Ref Environment
+            Period: 60
+            Stat: Sum
+
+  AlarmTopic:
+    Type: AWS::SNS::Topic
+    Condition: IsNotDevEnvironment
+    Properties:
+      Subscription:
+        - Protocol: email
+          Endpoint: !Sub "{{resolve:ssm:/alerting/email-address}}"
+
+  AlarmToPublishTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Condition: IsNotDevEnvironment
+    Properties:
+      Topics:
+        - !Ref AlarmTopic
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action: sns:Publish
+            Resource: !Ref AlarmTopic
+            Principal:
+              Service: 'cloudwatch.amazonaws.com'
+            Condition:
+              ArnLike:
+                AWS:SourceArn: !Sub 'arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:*'
+
 Outputs:
 
   StackName:

--- a/integration-tests/src/test/resources/cucumber.properties
+++ b/integration-tests/src/test/resources/cucumber.properties
@@ -1,0 +1,2 @@
+cucumber.publish.enabled=false
+cucumber.publish.quiet=true


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

CloudWatch Alerts on the following errors in the non-dev KBV accounts:
*  lambda errors for all lambdas in the account
* API Gateway 5XX errors for all APIGWs in the account
* API Gateway 4XX errors for all APIGWs in the account, with a slightly higher breach threshold


#### How error alerts are delivered
```mermaid
graph LR;
  subgraph CloudWatch_Alarms[CloudWatch Alarms]
    lambda_errors[lambda errors];
    5xx_errors[5XX errors];
    4xx_errors[4XX errors];
  end
lambdas-- error event -->lambda_errors;
APIGW[API Gateway]-- 5XX event --> 5xx_errors;
APIGW-- 4XX event --> 4xx_errors;
 lambda_errors-->AlarmTopic[SNS Alarm Topic];
5xx_errors-->AlarmTopic;
4xx_errors-->AlarmTopic;
AlarmTopic-->Email;
```

Alerts are delivered to an email mailing list. The email address is configured as an SSM parameter in the prod account by hand. @mrdoodles how can we set this non-public email address in our infra code?

Check out the [AWS docs on how alarms are evaluated](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html).

💡 Once we're happy with these Alarms, we can use them in canary deploys - [example](https://github.com/aws-samples/aws-serverless-books-api-sample/blob/985e8f00649633504e9c593baa86da79f1974c96/template.yml#L102-L107).


✅ This has been tested in dev against the SessionFunction and it delivers `ALARAM` and `OK` emails as expected.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-541](https://govukverify.atlassian.net/browse/OJ-541)
