### PR TITLE
OJ-985 update logging subscription filters

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -318,6 +318,14 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref PublicKBVApiAccessLogGroup
 
+  PublicKBVApiAccessLogGroupSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevEnvironment
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+      FilterPattern: ""
+      LogGroupName: !Ref PublicKBVApiAccessLogGroup
+
   PrivateKBVApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
     Condition: IsNotDevEnvironment
@@ -337,6 +345,13 @@ Resources:
     Condition: IsNotDevEnvironment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
+      FilterPattern: ""
+      LogGroupName: !Ref PrivateKBVApiAccessLogGroup
+  PrivateKBVApiAccessLogGroupSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevEnvironment
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
       FilterPattern: ""
       LogGroupName: !Ref PrivateKBVApiAccessLogGroup
 
@@ -419,6 +434,14 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref KBVQuestionFunctionLogGroup
 
+  KBVQuestionFunctionLogGroupSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevEnvironment
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+      FilterPattern: ""
+      LogGroupName: !Ref KBVQuestionFunctionLogGroup
+
   KBVAnswerFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -494,6 +517,14 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref KBVAnswerFunctionLogGroup
 
+  KBVAnswerFunctionLogGroupSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevEnvironment
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+      FilterPattern: ""
+      LogGroupName: !Ref KBVAnswerFunctionLogGroup
+
   KBVAbandonFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -532,6 +563,14 @@ Resources:
     Condition: IsNotDevEnvironment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
+      FilterPattern: ""
+      LogGroupName: !Ref KBVAbandonFunctionLogGroup
+
+  KBVAbandonFunctionLogGroupSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevEnvironment
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
       FilterPattern: ""
       LogGroupName: !Ref KBVAbandonFunctionLogGroup
 
@@ -590,6 +629,14 @@ Resources:
     Condition: IsNotDevEnvironment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
+      FilterPattern: ""
+      LogGroupName: !Ref IssueCredentialFunctionLogGroup
+
+  IssueCredentialFunctionLogGroupSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevEnvironment
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
       FilterPattern: ""
       LogGroupName: !Ref IssueCredentialFunctionLogGroup
 


### PR DESCRIPTION
## Proposed changes

### What changed

Add both old non python and new python subscription filters for splunk

### Why did it change

Requirement to use the new python subscription filters but to keep the old filters to ensure no logs get lost

### Issue tracking

- [OJ-985](https://govukverify.atlassian.net/browse/OJ-985)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks