### PR TITLE
BAU: Change Common Stack name to local

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -23,5 +23,5 @@ sam deploy --stack-name "$stack_name" \
    Environment=dev \
    AuditEventNamePrefix=/common-cri-parameters/KbvAuditEventNamePrefix \
    CriIdentifier=/common-cri-parameters/KbvCriIdentifier \
-   CommonStackName=kbv-common-cri-api \
+   CommonStackName=kbv-common-cri-api-local \
    SecretPrefix=kbv-cri-api


### PR DESCRIPTION
## Proposed changes

In `deploy.sh` common stack name should be pointing to the local common api stack



## Checklists


- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks