### PR TITLE
OJ-990: Use lib 1.1.5 VC signed concat format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ ext {
 		mockito					 : "4.3.1",
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
-		cri_common_lib           : "1.1.2"
+		cri_common_lib           : "1.1.5"
 	]
 }
 


### PR DESCRIPTION
## Proposed changes

As a consequence to

https://github.com/alphagov/di-ipv-config/pull/958
https://github.com/alphagov/di-ipv-stubs/pull/160

### What changed

Stub are now verifiying the JWT from the VC

### Why did it change

There is the need to verify that the JWT produce is coming from the expected party
