### PR TITLE
OJ-1017 KBV: sum API gateway errors across public and private gateways for Alarm

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -855,8 +855,19 @@ Resources:
               Namespace: AWS/ApiGateway
               MetricName: 5XXError
               Dimensions:
-                - Name: Stage
-                  Value: !Ref Environment
+                - Name: ApiName
+                  Value: !Sub "kbv-cri-${AWS::StackName}"
+            Period: 300
+            Stat: Sum
+        - Id: m2
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: 5XXError
+              Dimensions:
+                - Name: ApiName
+                  Value: !Sub "kbv-cri-private-${AWS::StackName}"
             Period: 300
             Stat: Sum
 
@@ -888,8 +899,19 @@ Resources:
               Namespace: AWS/ApiGateway
               MetricName: 4XXError
               Dimensions:
-                - Name: Stage
-                  Value: !Ref Environment
+                - Name: ApiName
+                  Value: !Sub "kbv-cri-${AWS::StackName}"
+            Period: 300
+            Stat: Sum
+        - Id: m2
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: 4XXError
+              Dimensions:
+                - Name: ApiName
+                  Value: !Sub "kbv-cri-private-${AWS::StackName}"
             Period: 300
             Stat: Sum
 Outputs:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes


For 5xx and 4x errors, use the sum of errors across the public and private API gateways.
Previously we used the sum of the API stage, and this didn't seem to work.

The sum expression e1 is the only metric with ReturnData: true so this is the single metric that makes up the alarm.

We've already landed this for Address with https://github.com/alphagov/di-ipv-cri-address-api/pull/224

ℹ️  Check that the `ApiName` value in this PR matches the api name for the API gateway resource.

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1017](https://govukverify.atlassian.net/browse/OJ-1017)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks