### PR TITLE
OJ-976 - Extend VC JWT expiry & use common VC claims builder

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -136,7 +136,7 @@
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 389
+        "line_number": 399
       }
     ],
     "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/fixtures/TestFixtures.java": [
@@ -195,5 +195,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-07T10:05:00Z"
+  "generated_at": "2022-11-07T16:00:03Z"
 }

--- a/README.md
+++ b/README.md
@@ -5,24 +5,6 @@
 **important:** One you've cloned the repo, run `pre-commit install` to install the pre-commit hooks.
 If you have not installed `pre-commit` then please do so [here](https://pre-commit.com/).
 
-## Check out submodules (First Time)
-> The first time you check out or clone the repository, you will need to run the following commands:
-
-`git submodule update --init --recursive`
-
-## Update submodules (Subsequent times)
-> Subsequent times you will need to run the following commands:
-
-`git submodule update --recursive`
-
-## Updating submodules to the latest "main" branch
-> You can also update the submodules to the latest "main" branch, but this is not done automatically
-> in case there have been changes made to the shared libraries you do not yet want to track
-
-cd into each submodule (folders are `/lib` and `/common-lambdas`) and run the following commands:
-
-`git checkout main && git pull`
-
 ## Build
 
 > Ensure that you are using the java version specified in `.sdkmanrc`.

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ ext {
 		mockito					 : "4.3.1",
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
-		cri_common_lib           : "1.1.5"
+		cri_common_lib           : "1.2.0"
 	]
 }
 

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -143,13 +143,23 @@ Mappings:
       integration: GDSCABINETUIIQ01U
       production: GDSCABINETUIIQ01U
 
+  # Only numeric values should be assigned here
   MaxJwtTtlMapping:
     Environment:
-      dev: 7200 # 2 hours
-      build: 7200 # 2 hours
-      staging: 7200 # 2 hours
-      integration: 7200 # 2 hours
-      production: 7200 # 2 hours
+      dev: 2
+      build: 2
+      staging: 2
+      integration: 2
+      production: 2
+
+  # Permitted values: SECONDS,MINUTES,HOURS,DAYS,MONTHS,YEARS
+  JwtTtlUnitMapping:
+    Environment:
+      dev: HOURS
+      build: HOURS
+      staging: HOURS
+      integration: HOURS
+      production: HOURS
 
 Resources:
   PublicKBVApi:
@@ -568,6 +578,7 @@ Resources:
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/KBVTableName"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/verifiableCredentialKmsSigningKeyId"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/MaxJwtTtl"
+              - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/JwtTtlUnit"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTableName"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/PersonIdentityTableName"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiable-credential/issuer"
@@ -694,6 +705,14 @@ Resources:
       Type: String
       Value: !FindInMap [MaxJwtTtlMapping, Environment, !Ref 'Environment']
       Description: default time to live for an JWT in (seconds)
+
+  JwtTtlUnitParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/JwtTtlUnit"
+      Type: String
+      Value: !FindInMap [ JwtTtlUnitMapping, Environment, !Ref Environment ]
+      Description: The unit for the time-to-live for an JWT e.g. (MONTHS)
 
   IIQAPIDatabaseModeParameter:
     Type: AWS::SSM::Parameter

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/VerifiableCredentialConstants.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/VerifiableCredentialConstants.java
@@ -1,38 +1,22 @@
 package uk.gov.di.ipv.cri.kbv.api.domain;
 
 public class VerifiableCredentialConstants {
-    public static final String VC_CONTEXT = "@context";
-    public static final String W3_BASE_CONTEXT = "https://www.w3.org/2018/credentials/v1";
-    public static final String DI_CONTEXT =
-            "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld";
-    public static final String VC_TYPE = "type";
-    public static final String VERIFIABLE_CREDENTIAL_TYPE = "VerifiableCredential";
-
     public static final String KBV_CREDENTIAL_TYPE = "IdentityCheckCredential";
-    public static final String VC_CREDENTIAL_SUBJECT = "credentialSubject";
-    public static final String VC_CLAIM = "vc";
 
     public static final String VC_ADDRESS_KEY = "address";
-
     public static final String VC_BIRTHDATE_KEY = "birthDate";
-
     public static final String VC_NAME_KEY = "name";
 
     public static final String VC_EVIDENCE_KEY = "evidence";
-
     public static final String VC_EVIDENCE_TYPE = "IdentityCheck";
 
     public static final String VC_THIRD_PARTY_KBV_CHECK_PASS = "AUTHENTICATED";
-
     public static final String VC_THIRD_PARTY_KBV_CHECK_NOT_AUTHENTICATED = "NOT AUTHENTICATED";
-
     public static final String VC_THIRD_PARTY_KBV_CHECK_UNABLE_TO_AUTHENTICATE =
             "UNABLE TO AUTHENTICATE";
-
     public static final String VC_THIRD_PARTY_KBV_CHECK_ABANDONED = "ABANDONED";
 
     public static final int VC_PASS_EVIDENCE_SCORE = 2;
-
     public static final int VC_FAIL_EVIDENCE_SCORE = 0;
 
     private VerifiableCredentialConstants() {}

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
@@ -4,11 +4,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.lambda.powertools.tracing.Tracing;
+import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.BirthDate;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentityDetailed;
@@ -16,45 +16,41 @@ import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.common.library.util.KMSSigner;
 import uk.gov.di.ipv.cri.common.library.util.SignedJWTFactory;
+import uk.gov.di.ipv.cri.common.library.util.VerifiableCredentialClaimsSetBuilder;
 import uk.gov.di.ipv.cri.kbv.api.domain.ContraIndicator;
 import uk.gov.di.ipv.cri.kbv.api.domain.Evidence;
 import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
 
-import java.time.Instant;
+import java.time.Clock;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static com.nimbusds.jwt.JWTClaimNames.EXPIRATION_TIME;
 import static com.nimbusds.jwt.JWTClaimNames.ISSUER;
-import static com.nimbusds.jwt.JWTClaimNames.NOT_BEFORE;
-import static com.nimbusds.jwt.JWTClaimNames.SUBJECT;
 import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.KBV_CREDENTIAL_TYPE;
 import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_ADDRESS_KEY;
 import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_BIRTHDATE_KEY;
-import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_CLAIM;
-import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_CREDENTIAL_SUBJECT;
 import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_EVIDENCE_KEY;
 import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_FAIL_EVIDENCE_SCORE;
 import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_NAME_KEY;
 import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_PASS_EVIDENCE_SCORE;
 import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_THIRD_PARTY_KBV_CHECK_NOT_AUTHENTICATED;
 import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_THIRD_PARTY_KBV_CHECK_PASS;
-import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_TYPE;
-import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VERIFIABLE_CREDENTIAL_TYPE;
 
 public class VerifiableCredentialService {
     private static final Logger LOGGER = LogManager.getLogger();
     public static final String METRIC_DIMENSION_KBV_VERIFICATION = "kbv_verification";
 
+    private final VerifiableCredentialClaimsSetBuilder vcClaimsSetBuilder;
     private final SignedJWTFactory signedJwtFactory;
     private final ConfigurationService configurationService;
-
     private final ObjectMapper objectMapper;
     private final EventProbe eventProbe;
 
+    @ExcludeFromGeneratedCoverageReport
     public VerifiableCredentialService() {
         this.configurationService = new ConfigurationService();
         this.signedJwtFactory =
@@ -66,52 +62,45 @@ public class VerifiableCredentialService {
                         .registerModule(new Jdk8Module())
                         .registerModule(new JavaTimeModule());
         this.eventProbe = new EventProbe();
+        this.vcClaimsSetBuilder =
+                new VerifiableCredentialClaimsSetBuilder(
+                        this.configurationService, Clock.systemUTC());
     }
 
     public VerifiableCredentialService(
             SignedJWTFactory signedClaimSetJwt,
             ConfigurationService configurationService,
             ObjectMapper objectMapper,
-            EventProbe eventProbe) {
+            EventProbe eventProbe,
+            VerifiableCredentialClaimsSetBuilder vcClaimsSetBuilder) {
         this.signedJwtFactory = signedClaimSetJwt;
         this.configurationService = configurationService;
         this.objectMapper = objectMapper;
         this.eventProbe = eventProbe;
+        this.vcClaimsSetBuilder = vcClaimsSetBuilder;
     }
 
     @Tracing
     public SignedJWT generateSignedVerifiableCredentialJwt(
             String subject, PersonIdentityDetailed personIdentity, KBVItem kbvItem)
             throws JOSEException {
-        var now = Instant.now();
-
+        long jwtTtl = this.configurationService.getMaxJwtTtl();
+        ChronoUnit jwtTtlUnit =
+                ChronoUnit.valueOf(this.configurationService.getParameterValue("JwtTtlUnit"));
         var claimsSet =
-                new JWTClaimsSet.Builder()
-                        .claim(SUBJECT, subject)
-                        .claim(ISSUER, configurationService.getVerifiableCredentialIssuer())
-                        .claim(NOT_BEFORE, now.getEpochSecond())
-                        .claim(
-                                EXPIRATION_TIME,
-                                now.plusSeconds(configurationService.getMaxJwtTtl())
-                                        .getEpochSecond())
-                        .claim(
-                                VC_CLAIM,
+                this.vcClaimsSetBuilder
+                        .subject(subject)
+                        .timeToLive(jwtTtl, jwtTtlUnit)
+                        .verifiableCredentialType(KBV_CREDENTIAL_TYPE)
+                        .verifiableCredentialSubject(
                                 Map.of(
-                                        VC_TYPE,
-                                        new String[] {
-                                            VERIFIABLE_CREDENTIAL_TYPE, KBV_CREDENTIAL_TYPE
-                                        },
-                                        VC_CREDENTIAL_SUBJECT,
-                                        Map.of(
-                                                VC_ADDRESS_KEY,
-                                                        convertAddresses(
-                                                                personIdentity.getAddresses()),
-                                                VC_NAME_KEY, personIdentity.getNames(),
-                                                VC_BIRTHDATE_KEY,
-                                                        convertBirthDates(
-                                                                personIdentity.getBirthDates())),
-                                        VC_EVIDENCE_KEY,
-                                        calculateEvidence(kbvItem)))
+                                        VC_ADDRESS_KEY,
+                                        convertAddresses(personIdentity.getAddresses()),
+                                        VC_NAME_KEY,
+                                        personIdentity.getNames(),
+                                        VC_BIRTHDATE_KEY,
+                                        convertBirthDates(personIdentity.getBirthDates())))
+                        .verifiableCredentialEvidence(calculateEvidence(kbvItem))
                         .build();
 
         return signedJwtFactory.createSignedJwt(claimsSet);


### PR DESCRIPTION
### What changed
- Updated the VC JWT time-to-live to 6 months
- Updated to the latest version of `cri-common-lib`
- Removed redundant constants from the `VerifiableCredentialConstants` class
- Updated VerifiableCredentialService to use the new common `VerifiableCredentialClaimsSetBuilder` class

### Why did it change
- There is a requirement to change the VC JWT time-to-live to 6 months
- There is unnecessary duplication of the logic to create the VC claims between the address, kbv & fraud CRIs

### Issue tracking
- [OJ-976](https://govukverify.atlassian.net/browse/OJ-976)
