### PR TITLE
OJ-1025: Add Abandon end point integration test

### DIFF
--- a/.github/workflows/pre-merge-integration-test.yml
+++ b/.github/workflows/pre-merge-integration-test.yml
@@ -74,7 +74,8 @@ jobs:
           export API_GATEWAY_ID_PRIVATE=$API_GATEWAY_ID_PRIVATE
           export API_GATEWAY_ID_PUBLIC=$API_GATEWAY_ID_PUBLIC
 
-          gradle cucumber -P tags=@pre_merge_happy
+          gradle integration-tests:cucumber
+
       - name: Delete integration test stack
         if: success()
         run: |

--- a/integration-tests/src/test/java/gov/uk/kbv/api/stepDefinitions/APISteps.java
+++ b/integration-tests/src/test/java/gov/uk/kbv/api/stepDefinitions/APISteps.java
@@ -26,13 +26,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class KbvApiHappyPathSteps {
+public class APISteps {
 
     public final String KBV_CRI_DEV = "kbv-cri-dev";
     public final String ENVIRONMENT = "/dev"; // dev, build, staging, integration
     public final String SESSION = ENVIRONMENT + "/session";
     public final String QUESTION = ENVIRONMENT + "/question";
     public final String ANSWER = ENVIRONMENT + "/answer";
+    public final String ABANDON = ENVIRONMENT + "/abandon";
     public final String AUTHORIZATION = ENVIRONMENT + "/authorization";
     public final String TOKEN = ENVIRONMENT + "/token";
     public final String CREDENTIAL_ISSUE = ENVIRONMENT + "/credential/issue";
@@ -377,6 +378,20 @@ public class KbvApiHappyPathSteps {
                         .setHeader("session-id", sessionId)
                         .POST(HttpRequest.BodyPublishers.ofString(POST_REQUEST_BODY))
                         .build();
+        response = sendHttpRequest(request);
+    }
+
+    @When("user chooses to abandon the question")
+    public void userChoosesToAbandonTheQuestion()
+            throws URISyntaxException, IOException, InterruptedException {
+        var request =
+                HttpRequest.newBuilder()
+                        .uri(new URIBuilder(getPrivateAPIEndpoint()).setPath(ABANDON).build())
+                        .setHeader("Accept", "application/json")
+                        .setHeader("session-id", sessionId)
+                        .POST(HttpRequest.BodyPublishers.noBody())
+                        .build();
+
         response = sendHttpRequest(request);
     }
 }

--- a/integration-tests/src/test/resources/features/KbvApiAbandonPath.feature
+++ b/integration-tests/src/test/resources/features/KbvApiAbandonPath.feature
@@ -1,0 +1,39 @@
+@pre_merge_abandon
+Feature: 3 out of 4 strategy. User has 2 KBV questions. Tests are run against the KBV Stub.
+  User chooses to abandon the question during KBV flow
+
+  Scenario: User abandons first question
+    Given user has the user identity in the form of a signed JWT string
+
+    #Session
+    When user sends a POST request to session end point
+    Then user gets a session-id
+
+    #First Question
+    When user sends a GET request to question end point
+    Then user gets status code 200
+
+    #Abandon
+    When user chooses to abandon the question
+    Then user gets status code 200
+
+  Scenario: User abandons second question
+    Given user has the user identity in the form of a signed JWT string
+
+    #Session
+    When user sends a POST request to session end point
+    Then user gets a session-id
+
+    #First Question
+    When user sends a GET request to question end point
+    Then user gets status code 200
+    And user answers the question correctly
+    Then user gets status code 200
+
+    #Second Question
+    When user sends a GET request to question end point
+    Then user gets status code 200
+
+    #Abandon
+    When user chooses to abandon the question
+    Then user gets status code 200


### PR DESCRIPTION
### Requirement
Add cucumber integration test to the `di-ipv-cri-kbv-api` for `abandon` end point

### What changed
- Added new `feature` file for Abandon end point
- New steps added to the `APISteps` file

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1025](https://govukverify.atlassian.net/browse/OJ-1025)

### Other considerations
To run the tests:

`STACK_NAME=di-ipv-cri-kbv-api-xxxx API_GATEWAY_ID_PRIVATE=xxxx API_GATEWAY_ID_PUBLIC=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=user IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://di-ipv-core-stub.london.cloudapps.digital" APIGW_API_KEY=xxxx gradle cucumber -P tags=@pre_merge_abandon`

To run all tests:

`STACK_NAME=di-ipv-cri-kbv-api-xxxx API_GATEWAY_ID_PRIVATE=xxxx API_GATEWAY_ID_PUBLIC=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=user IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://di-ipv-core-stub.london.cloudapps.digital" APIGW_API_KEY=xxxx gradle integration-tests:cucumber`


