### PR TITLE
Oj-937: add check details to vc response

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -152,28 +152,28 @@
         "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/fixtures/TestFixtures.java",
         "hashed_secret": "dfd787252ff7385f31a57bddf4597e207b13fda7",
         "is_verified": false,
-        "line_number": 14
+        "line_number": 28
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/fixtures/TestFixtures.java",
         "hashed_secret": "095f47d22e20655016ead16e0264f994b0ef5323",
         "is_verified": false,
-        "line_number": 16
+        "line_number": 30
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/fixtures/TestFixtures.java",
         "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
         "is_verified": false,
-        "line_number": 18
+        "line_number": 32
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/fixtures/TestFixtures.java",
         "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
         "is_verified": false,
-        "line_number": 18
+        "line_number": 32
       }
     ],
     "lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/data/TestData.java": [
@@ -202,5 +202,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-10T08:41:49Z"
+  "generated_at": "2022-11-23T17:21:07Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -148,28 +152,28 @@
         "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/fixtures/TestFixtures.java",
         "hashed_secret": "dfd787252ff7385f31a57bddf4597e207b13fda7",
         "is_verified": false,
-        "line_number": 12
+        "line_number": 14
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/fixtures/TestFixtures.java",
         "hashed_secret": "095f47d22e20655016ead16e0264f994b0ef5323",
         "is_verified": false,
-        "line_number": 14
+        "line_number": 16
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/fixtures/TestFixtures.java",
         "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
         "is_verified": false,
-        "line_number": 16
+        "line_number": 18
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/fixtures/TestFixtures.java",
         "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
         "is_verified": false,
-        "line_number": 16
+        "line_number": 18
       }
     ],
     "lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/data/TestData.java": [
@@ -198,5 +202,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-08T10:05:19Z"
+  "generated_at": "2022-11-10T08:41:49Z"
 }

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -582,6 +582,7 @@ Resources:
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTableName"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/PersonIdentityTableName"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiable-credential/issuer"
+              - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/kbv-cri-api-v1/quality/mappings"
         - Statement:
             Effect: Allow
             Action:

--- a/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
+++ b/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
@@ -200,7 +200,7 @@ public class QuestionAnswerHandler
         kbvItem.setQuestionState(objectMapper.writeValueAsString(questionState));
         kbvStorageService.update(kbvItem);
 
-        return questionState.hasAtLeastOneUnAnswered();
+        return questionState.hasAtLeastOneUnanswered();
     }
 
     private APIGatewayProxyResponseEvent handleException(

--- a/lambdas/answer/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandlerTest.java
+++ b/lambdas/answer/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandlerTest.java
@@ -110,7 +110,7 @@ class QuestionAnswerHandlerTest {
                 .thenReturn(questionStateMock);
         when(mockObjectMapper.writeValueAsString(questionStateMock)).thenReturn("question-state");
         doNothing().when(mockKBVStorageService).update(kbvItemMock);
-        when(questionStateMock.hasAtLeastOneUnAnswered()).thenReturn(true);
+        when(questionStateMock.hasAtLeastOneUnanswered()).thenReturn(true);
 
         APIGatewayProxyResponseEvent result =
                 questionAnswerHandler.handleRequest(input, contextMock);
@@ -148,7 +148,7 @@ class QuestionAnswerHandlerTest {
                 .thenReturn(questionStateMock);
         when(mockObjectMapper.readValue(REQUEST_PAYLOAD, QuestionAnswer.class))
                 .thenReturn(questionAnswerMock);
-        when(questionStateMock.hasAtLeastOneUnAnswered()).thenReturn(false);
+        when(questionStateMock.hasAtLeastOneUnanswered()).thenReturn(false);
         when(resultsMock.getAnswerSummary()).thenReturn(mockAnswerSummary);
         when(questionsResponseMock.getResults()).thenReturn(resultsMock);
         when(mockAnswerSummary.getQuestionsAsked()).thenReturn(totalQuestionsAsked);
@@ -174,9 +174,8 @@ class QuestionAnswerHandlerTest {
         assertEquals(mockSessionItem, auditEventContextArgCaptor.getValue().getSessionItem());
         assertEquals(
                 createRequestHeaders(), auditEventContextArgCaptor.getValue().getRequestHeaders());
-        Map<String, Object> auditEventExtensionEntries =
-                (Map<String, Object>)
-                        auditEventExtensionsArgCaptor.getValue().get("experianIiqResponse");
+        Map<?, ?> auditEventExtensionEntries =
+                (Map<?, ?>) auditEventExtensionsArgCaptor.getValue().get("experianIiqResponse");
         assertNotNull(auditEventExtensionEntries);
         assertEquals(responseStatus, auditEventExtensionEntries.get("outcome"));
         assertEquals(totalQuestionsAsked, auditEventExtensionEntries.get("totalQuestionsAsked"));
@@ -209,7 +208,7 @@ class QuestionAnswerHandlerTest {
         when(mockObjectMapper.readValue(REQUEST_PAYLOAD, QuestionAnswer.class))
                 .thenReturn(questionAnswerMock);
         when(mockObjectMapper.writeValueAsString(questionStateMock)).thenReturn("question-state");
-        when(questionStateMock.hasAtLeastOneUnAnswered()).thenReturn(false);
+        when(questionStateMock.hasAtLeastOneUnanswered()).thenReturn(false);
         when(mockKBVGateway.submitAnswers(any())).thenReturn(questionsResponseMock);
         when(questionsResponseMock.hasQuestions()).thenReturn(true);
         doNothing().when(questionStateMock).setQAPairs(any());
@@ -244,7 +243,7 @@ class QuestionAnswerHandlerTest {
         when(mockObjectMapper.readValue(REQUEST_PAYLOAD, QuestionAnswer.class))
                 .thenReturn(questionAnswerMock);
         when(mockObjectMapper.writeValueAsString(questionStateMock)).thenReturn("question-state");
-        when(questionStateMock.hasAtLeastOneUnAnswered()).thenReturn(false);
+        when(questionStateMock.hasAtLeastOneUnanswered()).thenReturn(false);
         when(mockKBVGateway.submitAnswers(any())).thenReturn(questionsResponseMock);
         when(questionsResponseMock.hasQuestions()).thenReturn(true);
 
@@ -375,7 +374,7 @@ class QuestionAnswerHandlerTest {
                 .thenReturn(questionStateMock);
         when(mockObjectMapper.readValue(REQUEST_PAYLOAD, QuestionAnswer.class))
                 .thenReturn(questionAnswerMock);
-        when(questionStateMock.hasAtLeastOneUnAnswered()).thenReturn(false);
+        when(questionStateMock.hasAtLeastOneUnanswered()).thenReturn(false);
         when(mockKBVGateway.submitAnswers(any())).thenReturn(questionsResponseMock);
         when(mockObjectMapper.writeValueAsString(any())).thenReturn("question-response");
         when(questionsResponseMock.getResults()).thenReturn(null);
@@ -535,16 +534,11 @@ class QuestionAnswerHandlerTest {
     private QuestionsResponse getQuestionResponseWithResults(
             String authenticationResult, KbvQuestionAnswerSummary kbvQuestionAnswerSummary) {
         QuestionsResponse questionsResponse = new QuestionsResponse();
-        KbvResult kbvResult = getKbvResult("END");
+        KbvResult kbvResult = new KbvResult();
+        kbvResult.setNextTransId(new String[] {"END"});
         kbvResult.setAuthenticationResult(authenticationResult);
         kbvResult.setAnswerSummary(kbvQuestionAnswerSummary);
         questionsResponse.setResults(kbvResult);
         return questionsResponse;
-    }
-
-    private KbvResult getKbvResult(String transactionValue) {
-        KbvResult kbvResult = new KbvResult();
-        kbvResult.setNextTransId(new String[] {transactionValue});
-        return kbvResult;
     }
 }

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/CheckDetail.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/CheckDetail.java
@@ -1,0 +1,32 @@
+package uk.gov.di.ipv.cri.kbv.api.domain;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CheckDetail {
+    @JsonProperty("checkMethod")
+    private String checkMethod = "kbv";
+
+    @JsonProperty("kbvResponseMode")
+    private String kbvResponseMode = "multiple_choice";
+
+    @JsonProperty("kbvQuality")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Integer kbvQuality;
+
+    public Integer getKbvQuality() {
+        return kbvQuality;
+    }
+
+    public void setKbvQuality(int kbvQuality) {
+        this.kbvQuality = kbvQuality;
+    }
+
+    public String getCheckMethod() {
+        return this.checkMethod;
+    }
+
+    public String getKbvResponseMode() {
+        return this.kbvResponseMode;
+    }
+}

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/Evidence.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/Evidence.java
@@ -1,7 +1,9 @@
 package uk.gov.di.ipv.cri.kbv.api.domain;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class Evidence {
     private String txn;
     private Integer verificationScore;

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/Evidence.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/Evidence.java
@@ -6,6 +6,8 @@ public class Evidence {
     private String txn;
     private Integer verificationScore;
     private ContraIndicator[] ci;
+    private CheckDetail[] checkDetails;
+    private CheckDetail[] failedCheckDetails;
 
     public String getTxn() {
         return txn;
@@ -34,5 +36,21 @@ public class Evidence {
 
     public ContraIndicator[] getCi() {
         return ci;
+    }
+
+    public CheckDetail[] getCheckDetails() {
+        return checkDetails;
+    }
+
+    public void setCheckDetails(CheckDetail[] checkDetails) {
+        this.checkDetails = checkDetails;
+    }
+
+    public CheckDetail[] getFailedCheckDetails() {
+        return failedCheckDetails;
+    }
+
+    public void setFailedCheckDetails(CheckDetail[] failedCheckDetails) {
+        this.failedCheckDetails = failedCheckDetails;
     }
 }

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/KbvQuality.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/KbvQuality.java
@@ -1,0 +1,20 @@
+package uk.gov.di.ipv.cri.kbv.api.domain;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public enum KbvQuality {
+    LOW(1),
+    MEDIUM(2),
+    HIGH(3);
+
+    private final int value;
+
+    private KbvQuality(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+}

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/VerifiableCredentialConstants.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/VerifiableCredentialConstants.java
@@ -9,12 +9,8 @@ public class VerifiableCredentialConstants {
 
     public static final String VC_EVIDENCE_KEY = "evidence";
     public static final String VC_EVIDENCE_TYPE = "IdentityCheck";
-
     public static final String VC_THIRD_PARTY_KBV_CHECK_PASS = "AUTHENTICATED";
     public static final String VC_THIRD_PARTY_KBV_CHECK_NOT_AUTHENTICATED = "NOT AUTHENTICATED";
-    public static final String VC_THIRD_PARTY_KBV_CHECK_UNABLE_TO_AUTHENTICATE =
-            "UNABLE TO AUTHENTICATE";
-    public static final String VC_THIRD_PARTY_KBV_CHECK_ABANDONED = "ABANDONED";
 
     public static final int VC_PASS_EVIDENCE_SCORE = 2;
     public static final int VC_FAIL_EVIDENCE_SCORE = 0;

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
@@ -1,0 +1,70 @@
+package uk.gov.di.ipv.cri.kbv.api.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
+import uk.gov.di.ipv.cri.kbv.api.domain.ContraIndicator;
+import uk.gov.di.ipv.cri.kbv.api.domain.Evidence;
+import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
+
+import java.util.Map;
+import java.util.Objects;
+
+import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_FAIL_EVIDENCE_SCORE;
+import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_PASS_EVIDENCE_SCORE;
+import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_THIRD_PARTY_KBV_CHECK_NOT_AUTHENTICATED;
+import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_THIRD_PARTY_KBV_CHECK_PASS;
+
+public class EvidenceFactory {
+    public static final String METRIC_DIMENSION_KBV_VERIFICATION = "kbv_verification";
+    private final EventProbe eventProbe;
+    private static final Logger LOGGER = LogManager.getLogger();
+    private final ObjectMapper objectMapper;
+
+    @ExcludeFromGeneratedCoverageReport
+    public EvidenceFactory() {
+        this.objectMapper =
+                new ObjectMapper()
+                        .registerModule(new Jdk8Module())
+                        .registerModule(new JavaTimeModule());
+        this.eventProbe = new EventProbe();
+    }
+
+    public EvidenceFactory(ObjectMapper objectMapper, EventProbe eventProbe) {
+        this.objectMapper = objectMapper;
+        this.eventProbe = eventProbe;
+    }
+
+    public Object[] create(KBVItem kbvItem) {
+        Evidence evidence = new Evidence();
+        evidence.setTxn(kbvItem.getAuthRefNo());
+        if (hasMultipleIncorrectAnswers(kbvItem)) {
+            evidence.setVerificationScore(VC_FAIL_EVIDENCE_SCORE);
+            evidence.setCi(new ContraIndicator[] {ContraIndicator.V03});
+            logVcScore("fail");
+        } else if (VC_THIRD_PARTY_KBV_CHECK_PASS.equalsIgnoreCase(kbvItem.getStatus())) {
+            evidence.setVerificationScore(VC_PASS_EVIDENCE_SCORE);
+            logVcScore("pass");
+        } else {
+            evidence.setVerificationScore(VC_FAIL_EVIDENCE_SCORE);
+            logVcScore("fail");
+        }
+
+        return new Map[] {objectMapper.convertValue(evidence, Map.class)};
+    }
+
+    private boolean hasMultipleIncorrectAnswers(KBVItem kbvItem) {
+        return VC_THIRD_PARTY_KBV_CHECK_NOT_AUTHENTICATED.equalsIgnoreCase(kbvItem.getStatus())
+                && Objects.nonNull(kbvItem.getQuestionAnswerResultSummary())
+                && kbvItem.getQuestionAnswerResultSummary().getAnsweredIncorrect() > 1;
+    }
+
+    private void logVcScore(String result) {
+        eventProbe.addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, result));
+        LOGGER.info("kbv {}", result);
+    }
+}

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
@@ -49,8 +49,7 @@ public class VerifiableCredentialService {
                 new ObjectMapper()
                         .registerModule(new Jdk8Module())
                         .registerModule(new JavaTimeModule());
-        this.evidenceFactory =
-                new EvidenceFactory(this.objectMapper, new EventProbe());
+        this.evidenceFactory = new EvidenceFactory(this.objectMapper, new EventProbe());
         this.vcClaimsSetBuilder =
                 new VerifiableCredentialClaimsSetBuilder(
                         this.configurationService, Clock.systemUTC());
@@ -89,8 +88,7 @@ public class VerifiableCredentialService {
                                         personIdentity.getNames(),
                                         VC_BIRTHDATE_KEY,
                                         convertBirthDates(personIdentity.getBirthDates())))
-                        .verifiableCredentialEvidence(
-                                evidenceFactory.create(kbvItem))
+                        .verifiableCredentialEvidence(evidenceFactory.create(kbvItem))
                         .build();
 
         return signedJwtFactory.createSignedJwt(claimsSet);

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
@@ -5,8 +5,6 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jwt.SignedJWT;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
@@ -17,8 +15,6 @@ import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.common.library.util.KMSSigner;
 import uk.gov.di.ipv.cri.common.library.util.SignedJWTFactory;
 import uk.gov.di.ipv.cri.common.library.util.VerifiableCredentialClaimsSetBuilder;
-import uk.gov.di.ipv.cri.kbv.api.domain.ContraIndicator;
-import uk.gov.di.ipv.cri.kbv.api.domain.Evidence;
 import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
 
 import java.time.Clock;
@@ -27,28 +23,20 @@ import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import static com.nimbusds.jwt.JWTClaimNames.ISSUER;
 import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.KBV_CREDENTIAL_TYPE;
 import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_ADDRESS_KEY;
 import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_BIRTHDATE_KEY;
 import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_EVIDENCE_KEY;
-import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_FAIL_EVIDENCE_SCORE;
 import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_NAME_KEY;
-import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_PASS_EVIDENCE_SCORE;
-import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_THIRD_PARTY_KBV_CHECK_NOT_AUTHENTICATED;
-import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_THIRD_PARTY_KBV_CHECK_PASS;
 
 public class VerifiableCredentialService {
-    private static final Logger LOGGER = LogManager.getLogger();
-    public static final String METRIC_DIMENSION_KBV_VERIFICATION = "kbv_verification";
-
     private final VerifiableCredentialClaimsSetBuilder vcClaimsSetBuilder;
     private final SignedJWTFactory signedJwtFactory;
     private final ConfigurationService configurationService;
     private final ObjectMapper objectMapper;
-    private final EventProbe eventProbe;
+    private final EvidenceFactory evidenceFactory;
 
     @ExcludeFromGeneratedCoverageReport
     public VerifiableCredentialService() {
@@ -61,7 +49,8 @@ public class VerifiableCredentialService {
                 new ObjectMapper()
                         .registerModule(new Jdk8Module())
                         .registerModule(new JavaTimeModule());
-        this.eventProbe = new EventProbe();
+        this.evidenceFactory =
+                new EvidenceFactory(this.objectMapper, new EventProbe());
         this.vcClaimsSetBuilder =
                 new VerifiableCredentialClaimsSetBuilder(
                         this.configurationService, Clock.systemUTC());
@@ -71,12 +60,12 @@ public class VerifiableCredentialService {
             SignedJWTFactory signedClaimSetJwt,
             ConfigurationService configurationService,
             ObjectMapper objectMapper,
-            EventProbe eventProbe,
-            VerifiableCredentialClaimsSetBuilder vcClaimsSetBuilder) {
+            VerifiableCredentialClaimsSetBuilder vcClaimsSetBuilder,
+            EvidenceFactory evidenceFactory) {
         this.signedJwtFactory = signedClaimSetJwt;
         this.configurationService = configurationService;
         this.objectMapper = objectMapper;
-        this.eventProbe = eventProbe;
+        this.evidenceFactory = evidenceFactory;
         this.vcClaimsSetBuilder = vcClaimsSetBuilder;
     }
 
@@ -100,7 +89,8 @@ public class VerifiableCredentialService {
                                         personIdentity.getNames(),
                                         VC_BIRTHDATE_KEY,
                                         convertBirthDates(personIdentity.getBirthDates())))
-                        .verifiableCredentialEvidence(calculateEvidence(kbvItem))
+                        .verifiableCredentialEvidence(
+                                evidenceFactory.create(kbvItem))
                         .build();
 
         return signedJwtFactory.createSignedJwt(claimsSet);
@@ -111,7 +101,7 @@ public class VerifiableCredentialService {
                 ISSUER,
                 configurationService.getVerifiableCredentialIssuer(),
                 VC_EVIDENCE_KEY,
-                calculateEvidence(kbvItem));
+                evidenceFactory.create(kbvItem));
     }
 
     @SuppressWarnings("unchecked")
@@ -146,34 +136,5 @@ public class VerifiableCredentialService {
                                                 .getValue()
                                                 .format(DateTimeFormatter.ISO_LOCAL_DATE)))
                 .toArray();
-    }
-
-    private Object[] calculateEvidence(KBVItem kbvItem) {
-        Evidence evidence = new Evidence();
-        evidence.setTxn(kbvItem.getAuthRefNo());
-        if (hasMultipleIncorrectAnswers(kbvItem)) {
-            evidence.setVerificationScore(VC_FAIL_EVIDENCE_SCORE);
-            evidence.setCi(new ContraIndicator[] {ContraIndicator.V03});
-            logVcScore("fail");
-        } else if (VC_THIRD_PARTY_KBV_CHECK_PASS.equalsIgnoreCase(kbvItem.getStatus())) {
-            evidence.setVerificationScore(VC_PASS_EVIDENCE_SCORE);
-            logVcScore("pass");
-        } else {
-            evidence.setVerificationScore(VC_FAIL_EVIDENCE_SCORE);
-            logVcScore("fail");
-        }
-
-        return new Map[] {objectMapper.convertValue(evidence, Map.class)};
-    }
-
-    private boolean hasMultipleIncorrectAnswers(KBVItem kbvItem) {
-        return VC_THIRD_PARTY_KBV_CHECK_NOT_AUTHENTICATED.equalsIgnoreCase(kbvItem.getStatus())
-                && Objects.nonNull(kbvItem.getQuestionAnswerResultSummary())
-                && kbvItem.getQuestionAnswerResultSummary().getAnsweredIncorrect() > 1;
-    }
-
-    private void logVcScore(String result) {
-        eventProbe.addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, result));
-        LOGGER.info("kbv {}", result);
     }
 }

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandlerTest.java
@@ -80,7 +80,8 @@ class IssueCredentialHandlerTest {
     @InjectMocks private IssueCredentialHandler handler;
 
     @Test
-    void shouldReturn200OkWhenIssueCredentialRequestIsValid() throws JOSEException, SqsException {
+    void shouldReturn200OkWhenIssueCredentialRequestIsValid()
+            throws JOSEException, SqsException, JsonProcessingException {
         ArgumentCaptor<AuditEventContext> auditEventContextArgCaptor =
                 ArgumentCaptor.forClass(AuditEventContext.class);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactoryTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactoryTest.java
@@ -1,25 +1,29 @@
 package uk.gov.di.ipv.cri.kbv.api.service;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
+import uk.gov.di.ipv.cri.kbv.api.domain.CheckDetail;
 import uk.gov.di.ipv.cri.kbv.api.domain.ContraIndicator;
 import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
+import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuality;
 import uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants;
 import uk.gov.di.ipv.cri.kbv.api.service.fixtures.TestFixtures;
 
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
@@ -27,7 +31,6 @@ import static uk.gov.di.ipv.cri.kbv.api.service.EvidenceFactory.METRIC_DIMENSION
 
 @ExtendWith(MockitoExtension.class)
 class EvidenceFactoryTest implements TestFixtures {
-    @InjectMocks
     private EvidenceFactory evidenceFactory;
     @Mock private EventProbe mockEventProbe;
     private final ObjectMapper objectMapper =
@@ -80,8 +83,7 @@ class EvidenceFactoryTest implements TestFixtures {
                 VerifiableCredentialConstants.VC_FAIL_EVIDENCE_SCORE,
                 getEvidenceAsMap(result).get("verificationScore"));
         assertEquals(
-                ContraIndicator.V03.toString(),
-                ((ArrayList) getEvidenceAsMap(result).get("ci")).get(0));
+                ContraIndicator.V03.toString(), ((List) getEvidenceAsMap(result).get("ci")).get(0));
     }
 
     @Test
@@ -102,6 +104,107 @@ class EvidenceFactoryTest implements TestFixtures {
                 VerifiableCredentialConstants.VC_FAIL_EVIDENCE_SCORE,
                 getEvidenceAsMap(result).get("verificationScore"));
         assertNull(getEvidenceAsMap(result).get("ci"));
+    }
+
+    @Test
+    void evidenceShouldContainCheckDetailsWhenKbvPasses() {
+        KBVItem kbvItem = new KBVItem();
+        kbvItem.setSessionId(UUID.randomUUID());
+        kbvItem.setAuthRefNo(UUID.randomUUID().toString());
+        kbvItem.setStatus("authenticated");
+        kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 3, 0));
+
+        var result = evidenceFactory.create(kbvItem);
+
+        verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+        assertNotNull(getEvidenceAsMap(result).get("checkDetails"));
+    }
+
+    @Test
+    void evidenceShouldHaveAsManyCheckDetailsItemsAsThereAreCorrectQuestionsWhenKbvPasses() {
+        KBVItem kbvItem = new KBVItem();
+        kbvItem.setSessionId(UUID.randomUUID());
+        kbvItem.setAuthRefNo(UUID.randomUUID().toString());
+        kbvItem.setStatus("authenticated");
+        kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 3, 0));
+
+        var result = evidenceFactory.create(kbvItem);
+
+        verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+        var checkDetailsResults = getEvidenceAsMap(result).get("checkDetails");
+        assertNotNull(checkDetailsResults);
+        var results =
+                objectMapper.convertValue(
+                        checkDetailsResults, new TypeReference<List<CheckDetail>>() {});
+        assertEquals(3, results.size());
+        results.forEach(
+                checkDetail -> {
+                    assertAll(
+                            () -> {
+                                assertEquals("kbv", checkDetail.getCheckMethod());
+                                assertEquals(
+                                        KbvQuality.LOW.getValue(), checkDetail.getKbvQuality());
+                                assertEquals("multiple_choice", checkDetail.getKbvResponseMode());
+                            });
+                });
+    }
+
+    @Test
+    void evidenceShouldHaveAsManyFailedCheckDetailsItemsAsThereAreInCorrectQuestionsWhenKbvFails() {
+        KBVItem kbvItem = new KBVItem();
+        kbvItem.setSessionId(UUID.randomUUID());
+        kbvItem.setAuthRefNo(UUID.randomUUID().toString());
+        kbvItem.setStatus("not Authenticated");
+        kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(4, 2, 2));
+
+        doNothing()
+                .when(mockEventProbe)
+                .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+        var result = evidenceFactory.create(kbvItem);
+
+        verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+        var failedCheckDetailsResults = getEvidenceAsMap(result).get("failedCheckDetails");
+        assertNotNull(failedCheckDetailsResults);
+        var results =
+                objectMapper.convertValue(
+                        failedCheckDetailsResults, new TypeReference<List<CheckDetail>>() {});
+        assertEquals(2, results.size());
+        results.forEach(
+                failedCheckDetail -> {
+                    assertAll(
+                            () -> {
+                                assertEquals("kbv", failedCheckDetail.getCheckMethod());
+                                assertNull(failedCheckDetail.getKbvQuality());
+                                assertEquals(
+                                        "multiple_choice", failedCheckDetail.getKbvResponseMode());
+                            });
+                });
+    }
+
+    @Test
+    void evidenceShouldNotHaveAnyOfTheCheckDetailsWhenKbvStatusIsAnyOtherValue() {
+        KBVItem kbvItem = new KBVItem();
+        kbvItem.setSessionId(UUID.randomUUID());
+        kbvItem.setAuthRefNo(UUID.randomUUID().toString());
+        kbvItem.setStatus("some unknown value");
+
+        doNothing()
+                .when(mockEventProbe)
+                .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+        var result = evidenceFactory.create(kbvItem);
+        verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+        assertEquals(
+                VerifiableCredentialConstants.VC_FAIL_EVIDENCE_SCORE,
+                getEvidenceAsMap(result).get("verificationScore"));
+
+        var failedCheckDetailsResults = getEvidenceAsMap(result).get("failedCheckDetails");
+        var checkDetailsResults = getEvidenceAsMap(result).get("CheckDetails");
+
+        assertNull(checkDetailsResults);
+        assertNull(failedCheckDetailsResults);
     }
 
     private Map getEvidenceAsMap(Object[] result) {

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactoryTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactoryTest.java
@@ -1,0 +1,110 @@
+package uk.gov.di.ipv.cri.kbv.api.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
+import uk.gov.di.ipv.cri.kbv.api.domain.ContraIndicator;
+import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
+import uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants;
+import uk.gov.di.ipv.cri.kbv.api.service.fixtures.TestFixtures;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static uk.gov.di.ipv.cri.kbv.api.service.EvidenceFactory.METRIC_DIMENSION_KBV_VERIFICATION;
+
+@ExtendWith(MockitoExtension.class)
+class EvidenceFactoryTest implements TestFixtures {
+    @InjectMocks
+    private EvidenceFactory evidenceFactory;
+    @Mock private EventProbe mockEventProbe;
+    private final ObjectMapper objectMapper =
+            new ObjectMapper()
+                    .registerModule(new Jdk8Module())
+                    .registerModule(new JavaTimeModule());
+
+    @BeforeEach
+    void setUp() {
+        evidenceFactory = new EvidenceFactory(objectMapper, mockEventProbe);
+    }
+
+    @Test
+    void shouldPassWhenKbvItemStatusIsAuthenticated() {
+        KBVItem kbvItem = new KBVItem();
+        kbvItem.setSessionId(UUID.randomUUID());
+        kbvItem.setAuthRefNo(UUID.randomUUID().toString());
+        kbvItem.setStatus("authenticated");
+        kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 3, 0));
+
+        doNothing()
+                .when(mockEventProbe)
+                .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+
+        var result = evidenceFactory.create(kbvItem);
+
+        verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+        assertEquals(
+                VerifiableCredentialConstants.VC_PASS_EVIDENCE_SCORE,
+                getEvidenceAsMap(result).get("verificationScore"));
+        assertNull(getEvidenceAsMap(result).get("ci"));
+    }
+
+    @Test
+    void shouldFailAndReturnContraIndicatorWhenMultipleAnswersAreIncorrect() {
+        KBVItem kbvItem = new KBVItem();
+        kbvItem.setSessionId(UUID.randomUUID());
+        kbvItem.setAuthRefNo(UUID.randomUUID().toString());
+        kbvItem.setStatus("not Authenticated");
+        kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(4, 2, 2));
+
+        doNothing()
+                .when(mockEventProbe)
+                .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+        var result = evidenceFactory.create(kbvItem);
+
+        verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+        assertEquals(
+                VerifiableCredentialConstants.VC_FAIL_EVIDENCE_SCORE,
+                getEvidenceAsMap(result).get("verificationScore"));
+        assertEquals(
+                ContraIndicator.V03.toString(),
+                ((ArrayList) getEvidenceAsMap(result).get("ci")).get(0));
+    }
+
+    @Test
+    void shouldFailWhenKbvItemStatusIsAnyOtherValue() {
+        KBVItem kbvItem = new KBVItem();
+        kbvItem.setSessionId(UUID.randomUUID());
+        kbvItem.setAuthRefNo(UUID.randomUUID().toString());
+        kbvItem.setStatus("some unknown value");
+
+        doNothing()
+                .when(mockEventProbe)
+                .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+        var result = evidenceFactory.create(kbvItem);
+        verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+        assertEquals(
+                VerifiableCredentialConstants.VC_FAIL_EVIDENCE_SCORE,
+                getEvidenceAsMap(result).get("verificationScore"));
+        assertNull(getEvidenceAsMap(result).get("ci"));
+    }
+
+    private Map getEvidenceAsMap(Object[] result) {
+        return (Map) result[0];
+    }
+}

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactoryTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactoryTest.java
@@ -1,10 +1,12 @@
 package uk.gov.di.ipv.cri.kbv.api.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -14,197 +16,377 @@ import uk.gov.di.ipv.cri.kbv.api.domain.CheckDetail;
 import uk.gov.di.ipv.cri.kbv.api.domain.ContraIndicator;
 import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
 import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuality;
+import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuestion;
+import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswer;
+import uk.gov.di.ipv.cri.kbv.api.domain.QuestionState;
 import uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants;
 import uk.gov.di.ipv.cri.kbv.api.service.fixtures.TestFixtures;
 
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
-import static uk.gov.di.ipv.cri.kbv.api.service.EvidenceFactory.METRIC_DIMENSION_KBV_VERIFICATION;
 
 @ExtendWith(MockitoExtension.class)
 class EvidenceFactoryTest implements TestFixtures {
+    private static final String METRIC_DIMENSION_KBV_VERIFICATION = "kbv_verification";
     private EvidenceFactory evidenceFactory;
-    @Mock private EventProbe mockEventProbe;
     private final ObjectMapper objectMapper =
             new ObjectMapper()
                     .registerModule(new Jdk8Module())
                     .registerModule(new JavaTimeModule());
+    @Mock private EventProbe mockEventProbe;
 
     @BeforeEach
     void setUp() {
-        evidenceFactory = new EvidenceFactory(objectMapper, mockEventProbe);
+        evidenceFactory =
+                new EvidenceFactory(
+                        objectMapper, mockEventProbe, KBV_QUESTION_QUALITY_MAPPING_SERIALIZED);
     }
 
-    @Test
-    void shouldPassWhenKbvItemStatusIsAuthenticated() {
-        KBVItem kbvItem = new KBVItem();
-        kbvItem.setSessionId(UUID.randomUUID());
-        kbvItem.setAuthRefNo(UUID.randomUUID().toString());
-        kbvItem.setStatus("authenticated");
-        kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 3, 0));
+    @Nested
+    class EvidenceVerificationScore {
+        @Test
+        void shouldPassWhenKbvItemStatusIsAuthenticated() throws JsonProcessingException {
+            KBVItem kbvItem = getKbvItem();
+            kbvItem.setStatus("authenticated");
+            kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 3, 0));
+            setKbvItemQuestionState(kbvItem, "First", "Second", "Third");
 
-        doNothing()
-                .when(mockEventProbe)
-                .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+            doNothing()
+                    .when(mockEventProbe)
+                    .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
 
-        var result = evidenceFactory.create(kbvItem);
+            var result = evidenceFactory.create(kbvItem);
 
-        verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
-        assertEquals(
-                VerifiableCredentialConstants.VC_PASS_EVIDENCE_SCORE,
-                getEvidenceAsMap(result).get("verificationScore"));
-        assertNull(getEvidenceAsMap(result).get("ci"));
+            verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+            assertEquals(
+                    VerifiableCredentialConstants.VC_PASS_EVIDENCE_SCORE,
+                    getEvidenceAsMap(result).get("verificationScore"));
+            assertNull(getEvidenceAsMap(result).get("ci"));
+        }
+
+        @Test
+        void shouldFailAndReturnContraIndicatorWhenMultipleAnswersAreIncorrect()
+                throws JsonProcessingException {
+            KBVItem kbvItem = getKbvItem();
+            kbvItem.setStatus("not Authenticated");
+            kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(4, 2, 2));
+            setKbvItemQuestionState(kbvItem, "First", "Second", "Third", "Fourth");
+
+            doNothing()
+                    .when(mockEventProbe)
+                    .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+            var result = evidenceFactory.create(kbvItem);
+
+            verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+            assertEquals(
+                    VerifiableCredentialConstants.VC_FAIL_EVIDENCE_SCORE,
+                    getEvidenceAsMap(result).get("verificationScore"));
+            assertEquals(
+                    ContraIndicator.V03.toString(),
+                    ((List) getEvidenceAsMap(result).get("ci")).get(0));
+        }
+
+        @Test
+        void shouldFailWhenKbvItemStatusIsAnyOtherValue() throws JsonProcessingException {
+            KBVItem kbvItem = getKbvItem();
+            kbvItem.setStatus("some unknown value");
+
+            doNothing()
+                    .when(mockEventProbe)
+                    .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+            var result = evidenceFactory.create(kbvItem);
+            verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+            assertEquals(
+                    VerifiableCredentialConstants.VC_FAIL_EVIDENCE_SCORE,
+                    getEvidenceAsMap(result).get("verificationScore"));
+            assertNull(getEvidenceAsMap(result).get("ci"));
+        }
     }
 
-    @Test
-    void shouldFailAndReturnContraIndicatorWhenMultipleAnswersAreIncorrect() {
-        KBVItem kbvItem = new KBVItem();
-        kbvItem.setSessionId(UUID.randomUUID());
-        kbvItem.setAuthRefNo(UUID.randomUUID().toString());
-        kbvItem.setStatus("not Authenticated");
-        kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(4, 2, 2));
+    @Nested
+    class EvidenceCheckDetails {
+        @Test
+        void shouldContainCheckDetailsWhenKbvPasses() throws JsonProcessingException {
+            KBVItem kbvItem = getKbvItem();
+            kbvItem.setStatus("authenticated");
+            kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 3, 0));
+            setKbvItemQuestionState(kbvItem, "First", "Second", "Third");
 
-        doNothing()
-                .when(mockEventProbe)
-                .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+            var result = evidenceFactory.create(kbvItem);
 
-        var result = evidenceFactory.create(kbvItem);
+            verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+            assertNotNull(getEvidenceAsMap(result).get("checkDetails"));
+        }
 
-        verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
-        assertEquals(
-                VerifiableCredentialConstants.VC_FAIL_EVIDENCE_SCORE,
-                getEvidenceAsMap(result).get("verificationScore"));
-        assertEquals(
-                ContraIndicator.V03.toString(), ((List) getEvidenceAsMap(result).get("ci")).get(0));
-    }
+        @Test
+        void shouldHaveAsManyCheckDetailsItemsAsThereAreCorrectQuestionsWhenKbvPasses()
+                throws JsonProcessingException {
+            KBVItem kbvItem = getKbvItem();
+            kbvItem.setStatus("authenticated");
+            kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 3, 0));
+            setKbvItemQuestionState(kbvItem, "First", "Second", "Third");
+            var result = evidenceFactory.create(kbvItem);
 
-    @Test
-    void shouldFailWhenKbvItemStatusIsAnyOtherValue() {
-        KBVItem kbvItem = new KBVItem();
-        kbvItem.setSessionId(UUID.randomUUID());
-        kbvItem.setAuthRefNo(UUID.randomUUID().toString());
-        kbvItem.setStatus("some unknown value");
+            verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+            var checkDetailsResults = getEvidenceAsMap(result).get("checkDetails");
 
-        doNothing()
-                .when(mockEventProbe)
-                .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+            var results =
+                    objectMapper.convertValue(
+                            checkDetailsResults, new TypeReference<List<CheckDetail>>() {});
+            assertEquals(3, results.size());
+            assertNotNull(checkDetailsResults);
+            assertNull(getEvidenceAsMap(result).get("failedCheckDetails"));
+            results.forEach(
+                    checkDetail -> {
+                        assertAll(
+                                () -> {
+                                    assertEquals("kbv", checkDetail.getCheckMethod());
+                                    assertEquals(
+                                            KbvQuality.LOW.getValue(), checkDetail.getKbvQuality());
+                                    assertEquals(
+                                            "multiple_choice", checkDetail.getKbvResponseMode());
+                                });
+                    });
+        }
 
-        var result = evidenceFactory.create(kbvItem);
-        verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+        @Test
+        void shouldReturnLowerKbvQualityWhenOnlyOneQuestionWasInitiallyAnsweredCorrectly()
+                throws JsonProcessingException {
+            KBVItem kbvItem = getKbvItem();
+            kbvItem.setStatus("authenticated");
+            kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(4, 3, 1));
+            List<KbvQuestion> kbvQuestionsFirstSecond = getKbvQuestions("First", "Second");
+            List<QuestionAnswer> questionFirstSecondAnswers = getQuestionAnswers("First", "Second");
+            List<KbvQuestion> kbvQuestionsThirdFourth = getKbvQuestions("Third", "Fourth");
+            List<QuestionAnswer> questionThirdFourthAnswers = getQuestionAnswers("Third", "Fourth");
+            QuestionState questionState = new QuestionState();
+            questionState.setQAPairs(kbvQuestionsFirstSecond.toArray(KbvQuestion[]::new));
+            questionState =
+                    loadKbvQuestionStateWithAnswers(
+                            questionState, kbvQuestionsFirstSecond, questionFirstSecondAnswers);
 
-        assertEquals(
-                VerifiableCredentialConstants.VC_FAIL_EVIDENCE_SCORE,
-                getEvidenceAsMap(result).get("verificationScore"));
-        assertNull(getEvidenceAsMap(result).get("ci"));
-    }
+            questionState.setQAPairs(kbvQuestionsThirdFourth.toArray(KbvQuestion[]::new));
+            questionState =
+                    loadKbvQuestionStateWithAnswers(
+                            questionState, kbvQuestionsThirdFourth, questionThirdFourthAnswers);
 
-    @Test
-    void evidenceShouldContainCheckDetailsWhenKbvPasses() {
-        KBVItem kbvItem = new KBVItem();
-        kbvItem.setSessionId(UUID.randomUUID());
-        kbvItem.setAuthRefNo(UUID.randomUUID().toString());
-        kbvItem.setStatus("authenticated");
-        kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 3, 0));
+            kbvItem.setQuestionState(new ObjectMapper().writeValueAsString(questionState));
 
-        var result = evidenceFactory.create(kbvItem);
+            evidenceFactory =
+                    new EvidenceFactory(
+                            objectMapper,
+                            mockEventProbe,
+                            objectMapper.readValue(
+                                    "{\"First\":4,\"Second\": 5, \"Third\": 9, \"Fourth\": 9}",
+                                    Map.class));
 
-        verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
-        assertNotNull(getEvidenceAsMap(result).get("checkDetails"));
-    }
+            var result = evidenceFactory.create(kbvItem);
 
-    @Test
-    void evidenceShouldHaveAsManyCheckDetailsItemsAsThereAreCorrectQuestionsWhenKbvPasses() {
-        KBVItem kbvItem = new KBVItem();
-        kbvItem.setSessionId(UUID.randomUUID());
-        kbvItem.setAuthRefNo(UUID.randomUUID().toString());
-        kbvItem.setStatus("authenticated");
-        kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 3, 0));
+            verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+            var checkDetailsResults = getEvidenceAsMap(result).get("checkDetails");
 
-        var result = evidenceFactory.create(kbvItem);
+            var results =
+                    objectMapper.convertValue(
+                            checkDetailsResults, new TypeReference<List<CheckDetail>>() {});
+            assertNotNull(checkDetailsResults);
+            assertNotNull(getEvidenceAsMap(result).get("failedCheckDetails"));
 
-        verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
-        var checkDetailsResults = getEvidenceAsMap(result).get("checkDetails");
-        assertNotNull(checkDetailsResults);
-        var results =
-                objectMapper.convertValue(
-                        checkDetailsResults, new TypeReference<List<CheckDetail>>() {});
-        assertEquals(3, results.size());
-        results.forEach(
-                checkDetail -> {
-                    assertAll(
-                            () -> {
-                                assertEquals("kbv", checkDetail.getCheckMethod());
-                                assertEquals(
-                                        KbvQuality.LOW.getValue(), checkDetail.getKbvQuality());
-                                assertEquals("multiple_choice", checkDetail.getKbvResponseMode());
-                            });
-                });
-    }
+            assertEquals(3, results.size());
+            assertEquals(4, results.get(0).getKbvQuality());
+            assertEquals(5, results.get(1).getKbvQuality());
+            assertEquals(9, results.get(2).getKbvQuality());
+        }
 
-    @Test
-    void evidenceShouldHaveAsManyFailedCheckDetailsItemsAsThereAreInCorrectQuestionsWhenKbvFails() {
-        KBVItem kbvItem = new KBVItem();
-        kbvItem.setSessionId(UUID.randomUUID());
-        kbvItem.setAuthRefNo(UUID.randomUUID().toString());
-        kbvItem.setStatus("not Authenticated");
-        kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(4, 2, 2));
+        @Test
+        void shouldReturnActualKbvQualityWhenInitial2QuestionsAreAnsweredCorrectly()
+                throws JsonProcessingException {
+            KBVItem kbvItem = getKbvItem();
+            kbvItem.setStatus("authenticated");
+            kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(4, 3, 1));
+            List<KbvQuestion> kbvQuestionsFirstSecond = getKbvQuestions("First", "Second");
+            List<QuestionAnswer> questionFirstSecondAnswers = getQuestionAnswers("First", "Second");
+            List<KbvQuestion> kbvQuestionsThird = getKbvQuestions("Third");
+            List<QuestionAnswer> questionThirdAnswers = getQuestionAnswers("Third");
+            List<KbvQuestion> kbvQuestionsFourth = getKbvQuestions("Fourth");
+            List<QuestionAnswer> questionFourthAnswers = getQuestionAnswers("Fourth");
 
-        doNothing()
-                .when(mockEventProbe)
-                .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+            QuestionState questionState = new QuestionState();
+            questionState.setQAPairs(kbvQuestionsFirstSecond.toArray(KbvQuestion[]::new));
+            questionState =
+                    loadKbvQuestionStateWithAnswers(
+                            questionState, kbvQuestionsFirstSecond, questionFirstSecondAnswers);
 
-        var result = evidenceFactory.create(kbvItem);
+            questionState.setQAPairs(kbvQuestionsThird.toArray(KbvQuestion[]::new));
+            questionState =
+                    loadKbvQuestionStateWithAnswers(
+                            questionState, kbvQuestionsThird, questionThirdAnswers);
 
-        verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
-        var failedCheckDetailsResults = getEvidenceAsMap(result).get("failedCheckDetails");
-        assertNotNull(failedCheckDetailsResults);
-        var results =
-                objectMapper.convertValue(
-                        failedCheckDetailsResults, new TypeReference<List<CheckDetail>>() {});
-        assertEquals(2, results.size());
-        results.forEach(
-                failedCheckDetail -> {
-                    assertAll(
-                            () -> {
-                                assertEquals("kbv", failedCheckDetail.getCheckMethod());
-                                assertNull(failedCheckDetail.getKbvQuality());
-                                assertEquals(
-                                        "multiple_choice", failedCheckDetail.getKbvResponseMode());
-                            });
-                });
-    }
+            questionState.setQAPairs(kbvQuestionsFourth.toArray(KbvQuestion[]::new));
+            questionState =
+                    loadKbvQuestionStateWithAnswers(
+                            questionState, kbvQuestionsFourth, questionFourthAnswers);
 
-    @Test
-    void evidenceShouldNotHaveAnyOfTheCheckDetailsWhenKbvStatusIsAnyOtherValue() {
-        KBVItem kbvItem = new KBVItem();
-        kbvItem.setSessionId(UUID.randomUUID());
-        kbvItem.setAuthRefNo(UUID.randomUUID().toString());
-        kbvItem.setStatus("some unknown value");
+            kbvItem.setQuestionState(new ObjectMapper().writeValueAsString(questionState));
 
-        doNothing()
-                .when(mockEventProbe)
-                .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+            evidenceFactory =
+                    new EvidenceFactory(
+                            objectMapper,
+                            mockEventProbe,
+                            objectMapper.readValue(
+                                    "{\"First\":4,\"Second\": 5, \"Third\": 9, \"Fourth\": 8}",
+                                    Map.class));
 
-        var result = evidenceFactory.create(kbvItem);
-        verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+            var result = evidenceFactory.create(kbvItem);
 
-        assertEquals(
-                VerifiableCredentialConstants.VC_FAIL_EVIDENCE_SCORE,
-                getEvidenceAsMap(result).get("verificationScore"));
+            verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+            var checkDetailsResults = getEvidenceAsMap(result).get("checkDetails");
 
-        var failedCheckDetailsResults = getEvidenceAsMap(result).get("failedCheckDetails");
-        var checkDetailsResults = getEvidenceAsMap(result).get("CheckDetails");
+            var results =
+                    objectMapper.convertValue(
+                            checkDetailsResults, new TypeReference<List<CheckDetail>>() {});
+            assertNotNull(checkDetailsResults);
+            assertNotNull(getEvidenceAsMap(result).get("failedCheckDetails"));
 
-        assertNull(checkDetailsResults);
-        assertNull(failedCheckDetailsResults);
+            assertEquals(3, results.size());
+            assertEquals(4, results.get(0).getKbvQuality());
+            assertEquals(5, results.get(1).getKbvQuality());
+            assertEquals(8, results.get(2).getKbvQuality());
+        }
+
+        @Test
+        void shouldHave2FailedAnd2CheckDetails2of4KbvQuestionsAreInCorrect()
+                throws JsonProcessingException {
+            KBVItem kbvItem = getKbvItem();
+            kbvItem.setStatus("not Authenticated");
+            kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(4, 2, 2));
+            setKbvItemQuestionState(kbvItem, "First", "Second", "Third", "Fourth");
+
+            doNothing()
+                    .when(mockEventProbe)
+                    .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+            var result = evidenceFactory.create(kbvItem);
+
+            verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+            var failedCheckDetailsResultsNode = getEvidenceAsMap(result).get("failedCheckDetails");
+            var checkDetailsResultsNode = getEvidenceAsMap(result).get("checkDetails");
+            var checkDetailsResults =
+                    objectMapper.convertValue(
+                            checkDetailsResultsNode, new TypeReference<List<CheckDetail>>() {});
+            var failedCheckDetailsResults =
+                    objectMapper.convertValue(
+                            failedCheckDetailsResultsNode,
+                            new TypeReference<List<CheckDetail>>() {});
+
+            assertNotNull(failedCheckDetailsResultsNode);
+            assertEquals(2, failedCheckDetailsResults.size());
+            assertEquals(2, checkDetailsResults.size());
+            failedCheckDetailsResults.forEach(
+                    failedCheckDetail -> {
+                        assertAll(
+                                () -> {
+                                    assertEquals("kbv", failedCheckDetail.getCheckMethod());
+                                    assertNull(failedCheckDetail.getKbvQuality());
+                                    assertEquals(
+                                            "multiple_choice",
+                                            failedCheckDetail.getKbvResponseMode());
+                                });
+                    });
+        }
+
+        @Test
+        void showNoCheckDetailsWhenKbvStatusIsUnAuthenticatedButQuestionAnswerResultSummaryIsNull()
+                throws JsonProcessingException {
+            KBVItem kbvItem = getKbvItem();
+            kbvItem.setStatus("not Authenticated");
+            setKbvItemQuestionState(kbvItem, "First", "Second", "Third", "Fourth");
+            kbvItem.setQuestionAnswerResultSummary(null);
+
+            doNothing()
+                    .when(mockEventProbe)
+                    .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+            var result = evidenceFactory.create(kbvItem);
+
+            verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+            var failedCheckDetailsResults = getEvidenceAsMap(result).get("failedCheckDetails");
+            var checkDetailsResults = getEvidenceAsMap(result).get("CheckDetails");
+
+            assertNull(checkDetailsResults);
+            assertNull(failedCheckDetailsResults);
+        }
+
+        @Test
+        void showNoCheckDetailsWhenKbvStatusIsUnAuthenticatedButQuestionAskedIsZero()
+                throws JsonProcessingException {
+            KBVItem kbvItem = getKbvItem();
+            kbvItem.setStatus("not Authenticated");
+            setKbvItemQuestionState(kbvItem, "First", "Second", "Third", "Fourth");
+            kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(0, 0, 0));
+
+            doNothing()
+                    .when(mockEventProbe)
+                    .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+            var result = evidenceFactory.create(kbvItem);
+
+            verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+            var failedCheckDetailsResults = getEvidenceAsMap(result).get("failedCheckDetails");
+            var checkDetailsResults = getEvidenceAsMap(result).get("CheckDetails");
+
+            assertNull(checkDetailsResults);
+            assertNull(failedCheckDetailsResults);
+        }
+
+        @Test
+        void shouldNotHaveAnyOfTheCheckDetailsWhenKbvStatusIsAnyOtherValue()
+                throws JsonProcessingException {
+            KBVItem kbvItem = getKbvItem();
+            kbvItem.setStatus("some unknown value");
+
+            doNothing()
+                    .when(mockEventProbe)
+                    .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+            var result = evidenceFactory.create(kbvItem);
+            verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+            assertEquals(
+                    VerifiableCredentialConstants.VC_FAIL_EVIDENCE_SCORE,
+                    getEvidenceAsMap(result).get("verificationScore"));
+
+            var failedCheckDetailsResults = getEvidenceAsMap(result).get("failedCheckDetails");
+            var checkDetailsResults = getEvidenceAsMap(result).get("CheckDetails");
+
+            assertNull(checkDetailsResults);
+            assertNull(failedCheckDetailsResults);
+        }
+
+        @Test
+        void shouldFailWhenKbvItemEvidenceMappingDoesNotIncludeQuestion()
+                throws JsonProcessingException {
+            KBVItem kbvItem = getKbvItem();
+            kbvItem.setStatus("authenticated");
+            kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 3, 0));
+            setKbvItemQuestionState(kbvItem, "NA");
+
+            IllegalStateException thrown =
+                    assertThrows(
+                            IllegalStateException.class, () -> evidenceFactory.create(kbvItem));
+
+            assertEquals("QuestionId: NA may not be present in Mapping", thrown.getMessage());
+        }
     }
 
     private Map getEvidenceAsMap(Object[] result) {

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/fixtures/TestFixtures.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/fixtures/TestFixtures.java
@@ -1,5 +1,7 @@
 package uk.gov.di.ipv.cri.kbv.api.service.fixtures;
 
+import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuestionAnswerSummary;
+
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.ECPrivateKey;
@@ -21,5 +23,14 @@ public interface TestFixtures {
                         .generatePrivate(
                                 new PKCS8EncodedKeySpec(
                                         Base64.getDecoder().decode(EC_PRIVATE_KEY_1)));
+    }
+
+    default KbvQuestionAnswerSummary getKbvQuestionAnswerSummary(
+            int asked, int answeredCorrect, int answeredIncorrect) {
+        KbvQuestionAnswerSummary kbvQuestionAnswerSummary = new KbvQuestionAnswerSummary();
+        kbvQuestionAnswerSummary.setAnsweredCorrect(answeredCorrect);
+        kbvQuestionAnswerSummary.setAnsweredIncorrect(answeredIncorrect);
+        kbvQuestionAnswerSummary.setQuestionsAsked(asked);
+        return kbvQuestionAnswerSummary;
     }
 }

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/fixtures/TestFixtures.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/fixtures/TestFixtures.java
@@ -1,13 +1,27 @@
 package uk.gov.di.ipv.cri.kbv.api.service.fixtures;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
+import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuestion;
 import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuestionAnswerSummary;
+import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuestionOptions;
+import uk.gov.di.ipv.cri.kbv.api.domain.KbvResult;
+import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswer;
+import uk.gov.di.ipv.cri.kbv.api.domain.QuestionState;
 
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.ECPrivateKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Arrays;
 import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 public interface TestFixtures {
     String EC_PRIVATE_KEY_1 =
@@ -16,6 +30,16 @@ public interface TestFixtures {
             "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEE9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIMqVMxm2EdlSRjPkCV5NDyN9/RMmJLerY4H0vkXDjEDTg==";
     String EC_PUBLIC_JWK_1 =
             "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}";
+
+    String KBV_QUESTION_QUALITY_MAPPING =
+            "{\"First\":0,\"Second\": 0, \"Third\": 0, \"Fourth\": 0}";
+
+    Map<String, Integer> KBV_QUESTION_QUALITY_MAPPING_SERIALIZED =
+            Map.of(
+                    "First", 0,
+                    "Second", 0,
+                    "Third", 0,
+                    "Fourth", 0);
 
     default ECPrivateKey getPrivateKey() throws InvalidKeySpecException, NoSuchAlgorithmException {
         return (ECPrivateKey)
@@ -32,5 +56,124 @@ public interface TestFixtures {
         kbvQuestionAnswerSummary.setAnsweredIncorrect(answeredIncorrect);
         kbvQuestionAnswerSummary.setQuestionsAsked(asked);
         return kbvQuestionAnswerSummary;
+    }
+
+    default void setKbvItemQuestionState(KBVItem kbvItem) throws JsonProcessingException {
+        setKbvItemQuestionState(kbvItem, "First");
+    }
+
+    default void setKbvItemQuestionState(KBVItem kbvItem, String... questions)
+            throws JsonProcessingException {
+        List<KbvQuestion> kbvQuestions = getKbvQuestions(questions);
+        List<QuestionAnswer> questionAnswers = getQuestionAnswers(questions);
+
+        QuestionState questionStateWithAnswer =
+                getQuestionStateWithAnswer(kbvQuestions, questionAnswers);
+
+        kbvItem.setQuestionState(new ObjectMapper().writeValueAsString(questionStateWithAnswer));
+    }
+
+    default List<QuestionAnswer> getQuestionAnswers(String... questions) {
+        var questionAnswers =
+                Arrays.stream(questions)
+                        .map(
+                                questionId -> {
+                                    QuestionAnswer questionAnswer = new QuestionAnswer();
+                                    questionAnswer.setQuestionId(questionId);
+                                    return questionAnswer;
+                                })
+                        .collect(Collectors.toList());
+        return questionAnswers;
+    }
+
+    default List<KbvQuestion> getKbvQuestions(String... questions) {
+        var kbvQuestions =
+                Arrays.stream(questions).map(this::getQuestion).collect(Collectors.toList());
+        return kbvQuestions;
+    }
+
+    default QuestionState getQuestionStateWithAnswer(
+            List<KbvQuestion> kbvQuestions, List<QuestionAnswer> questionAnswers) {
+        return getQuestionStateWithAnswer(
+                kbvQuestions.toArray(KbvQuestion[]::new),
+                questionAnswers.toArray(QuestionAnswer[]::new));
+    }
+
+    default QuestionState getQuestionStateWithAnswer(
+            KbvQuestion[] kbvQuestions, QuestionAnswer[] questionAnswers) {
+        QuestionState questionState = createKbvQuestionStateWithQAPairs(kbvQuestions);
+
+        return getQuestionStateWithAnswer(questionState, kbvQuestions, questionAnswers);
+    }
+
+    default QuestionState loadKbvQuestionStateWithAnswers(
+            QuestionState questionState,
+            List<KbvQuestion> kbvQuestions,
+            List<QuestionAnswer> questionAnswers) {
+        return getQuestionStateWithAnswer(
+                questionState,
+                kbvQuestions.toArray(KbvQuestion[]::new),
+                questionAnswers.toArray(QuestionAnswer[]::new));
+    }
+
+    default QuestionState getQuestionStateWithAnswer(
+            QuestionState questionState,
+            KbvQuestion[] kbvQuestions,
+            QuestionAnswer[] questionAnswers) {
+
+        for (KbvQuestion question : kbvQuestions) {
+            Optional<QuestionAnswer> questionAnswer =
+                    Arrays.stream(questionAnswers)
+                            .filter(qa -> qa.getQuestionId().equals(question.getQuestionId()))
+                            .findFirst();
+            questionAnswer.ifPresent(
+                    ans -> {
+                        ans.setQuestionId(question.getQuestionId());
+                        ans.setAnswer(String.format("%s Answer", question.getQuestionId()));
+                        questionState.setAnswer(ans);
+                    });
+        }
+        return questionState;
+    }
+
+    default QuestionState createKbvQuestionStateWithQAPairs(List<KbvQuestion> kbvQuestions) {
+        return createKbvQuestionStateWithQAPairs(kbvQuestions.toArray(KbvQuestion[]::new));
+    }
+
+    default QuestionState createKbvQuestionStateWithQAPairs(
+            QuestionState questionState, KbvQuestion[] kbvQuestions) {
+        questionState.setQAPairs(kbvQuestions);
+        return questionState;
+    }
+
+    default QuestionState createKbvQuestionStateWithQAPairs(KbvQuestion[] kbvQuestions) {
+        QuestionState questionState = new QuestionState();
+        questionState.setQAPairs(kbvQuestions);
+        return questionState;
+    }
+
+    default KbvQuestion getQuestion(String questionId) {
+        KbvQuestionOptions questionOptions = new KbvQuestionOptions();
+        questionOptions.setIdentifier(questionId);
+        questionOptions.setFieldType("G");
+
+        KbvQuestion question = new KbvQuestion();
+        question.setQuestionId(questionId);
+        question.setQuestionOptions(questionOptions);
+
+        return question;
+    }
+
+    default KBVItem getKbvItem() {
+        KBVItem kbvItem = new KBVItem();
+        kbvItem.setSessionId(UUID.randomUUID());
+        kbvItem.setAuthRefNo(UUID.randomUUID().toString());
+        return kbvItem;
+    }
+
+    default KbvResult getKbvResult(String transactionValue) {
+        KbvResult kbvResult = new KbvResult();
+        kbvResult.setNextTransId(new String[] {transactionValue});
+        return kbvResult;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionState.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionState.java
@@ -4,13 +4,35 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class QuestionState {
     private List<QuestionAnswerPair> qaPairs = new ArrayList<>();
+    private List<List<QuestionAnswerPair>> allQaPairs = new ArrayList<>();
+
+    @JsonIgnore
+    public boolean isQaPairsASizeOf2() {
+        return allQaPairs.stream().allMatch(x -> x.stream().count() == 2);
+    }
+
+    @JsonIgnore
+    public Stream<String> getQuestionIdsFromQAPairs() {
+        return allQaPairs.stream()
+                .map(Collection::stream)
+                .flatMap(q -> q.map(QuestionAnswerPair::getQuestion))
+                .map(KbvQuestion::getQuestionId);
+    }
+
+    @JsonIgnore
+    public Stream<List<QuestionAnswerPair>> skipQaPairAtIndexOne() {
+        return allQaPairs.stream().filter(Predicate.not(q -> allQaPairs.indexOf(q) == 1));
+    }
 
     public void setAnswer(QuestionAnswer questionAnswer) {
         this.getQaPairs().stream()
@@ -36,9 +58,15 @@ public class QuestionState {
         return hasQuestions;
     }
 
+    public List<List<QuestionAnswerPair>> getAllQaPairs() {
+        return allQaPairs;
+    }
+
     public void setQAPairs(KbvQuestion[] questions) {
         this.qaPairs =
                 Arrays.stream(questions).map(QuestionAnswerPair::new).collect(Collectors.toList());
+        this.allQaPairs.add(
+                Arrays.stream(questions).map(QuestionAnswerPair::new).collect(Collectors.toList()));
     }
 
     public List<QuestionAnswerPair> getQaPairs() {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionState.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionState.java
@@ -17,8 +17,8 @@ public class QuestionState {
     private List<List<QuestionAnswerPair>> allQaPairs = new ArrayList<>();
 
     @JsonIgnore
-    public boolean isQaPairsASizeOf2() {
-        return allQaPairs.stream().allMatch(x -> x.stream().count() == 2);
+    public boolean allQuestionBatchSizesMatch(int expectedBatchSize) {
+        return allQaPairs.stream().allMatch(x -> x.size() == expectedBatchSize);
     }
 
     @JsonIgnore
@@ -98,7 +98,7 @@ public class QuestionState {
         return qaPairs.stream().allMatch(qa -> Objects.nonNull(qa.getAnswer()));
     }
 
-    public boolean hasAtLeastOneUnAnswered() {
+    public boolean hasAtLeastOneUnanswered() {
         return qaPairs.stream().anyMatch(qa -> Objects.isNull(qa.getAnswer()));
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionStateTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionStateTest.java
@@ -12,6 +12,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.cri.kbv.api.util.TestDataCreator.getExperianQuestionResponse;
+import static uk.gov.di.ipv.cri.kbv.api.util.TestDataCreator.getQuestionOne;
+import static uk.gov.di.ipv.cri.kbv.api.util.TestDataCreator.getQuestionTwo;
 
 @ExtendWith(MockitoExtension.class)
 class QuestionStateTest {
@@ -76,5 +79,63 @@ class QuestionStateTest {
         String result = sample.stream().reduce("", String::concat);
 
         assertEquals("END", result);
+    }
+
+    @Test
+    void questionStateShouldRetainOldQuestionsWhenNewQuestionsAreSetInBatchesOf2And2() {
+        var questionOne = getQuestionOne();
+        var questionTwo = getQuestionTwo();
+        var questionThree = getQuestionOne();
+        var questionFour = getQuestionTwo();
+        QuestionsResponse questionsResponse1 =
+                getExperianQuestionResponse(new KbvQuestion[] {questionOne, questionTwo});
+        QuestionsResponse questionsResponse2 =
+                getExperianQuestionResponse(new KbvQuestion[] {questionThree, questionFour});
+
+        questionState.setQAPairs(questionsResponse1.getQuestions());
+        questionState.setQAPairs(questionsResponse2.getQuestions());
+
+        assertTrue(questionState.isQaPairsASizeOf2());
+        assertEquals(4, questionState.getQuestionIdsFromQAPairs().count());
+    }
+
+    @Test
+    void questionStateShouldRetainOldQuestionsWhenNewQuestionsAreSetInBatchOf2by1by1() {
+        var questionOne = getQuestionOne();
+        var questionTwo = getQuestionTwo();
+        var questionThree = getQuestionOne();
+        var questionFour = getQuestionTwo();
+        QuestionsResponse questionsResponse12 =
+                getExperianQuestionResponse(new KbvQuestion[] {questionOne, questionTwo});
+        QuestionsResponse questionsResponse3 =
+                getExperianQuestionResponse(new KbvQuestion[] {questionThree});
+        QuestionsResponse questionsResponse4 =
+                getExperianQuestionResponse(new KbvQuestion[] {questionFour});
+        questionState.setQAPairs(questionsResponse12.getQuestions());
+        questionState.setQAPairs(questionsResponse3.getQuestions());
+        questionState.setQAPairs(questionsResponse4.getQuestions());
+
+        assertFalse(questionState.isQaPairsASizeOf2());
+        assertEquals(4, questionState.getQuestionIdsFromQAPairs().count());
+    }
+
+    @Test
+    void questionStateShouldfilterOutQAPairAtIndexOne() {
+        var questionOne = getQuestionOne();
+        var questionTwo = getQuestionTwo();
+        var questionThree = getQuestionOne();
+        var questionFour = getQuestionTwo();
+        QuestionsResponse questionsResponse12 =
+                getExperianQuestionResponse(new KbvQuestion[] {questionOne, questionTwo});
+        QuestionsResponse questionsResponse3 =
+                getExperianQuestionResponse(new KbvQuestion[] {questionThree});
+        QuestionsResponse questionsResponse4 =
+                getExperianQuestionResponse(new KbvQuestion[] {questionFour});
+        questionState.setQAPairs(questionsResponse12.getQuestions());
+        questionState.setQAPairs(questionsResponse3.getQuestions());
+        questionState.setQAPairs(questionsResponse4.getQuestions());
+
+        assertFalse(questionState.isQaPairsASizeOf2());
+        assertEquals(2, questionState.skipQaPairAtIndexOne().count());
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionStateTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionStateTest.java
@@ -95,7 +95,7 @@ class QuestionStateTest {
         questionState.setQAPairs(questionsResponse1.getQuestions());
         questionState.setQAPairs(questionsResponse2.getQuestions());
 
-        assertTrue(questionState.isQaPairsASizeOf2());
+        assertTrue(questionState.allQuestionBatchSizesMatch(2));
         assertEquals(4, questionState.getQuestionIdsFromQAPairs().count());
     }
 
@@ -115,7 +115,7 @@ class QuestionStateTest {
         questionState.setQAPairs(questionsResponse3.getQuestions());
         questionState.setQAPairs(questionsResponse4.getQuestions());
 
-        assertFalse(questionState.isQaPairsASizeOf2());
+        assertFalse(questionState.allQuestionBatchSizesMatch(2));
         assertEquals(4, questionState.getQuestionIdsFromQAPairs().count());
     }
 
@@ -135,7 +135,7 @@ class QuestionStateTest {
         questionState.setQAPairs(questionsResponse3.getQuestions());
         questionState.setQAPairs(questionsResponse4.getQuestions());
 
-        assertFalse(questionState.isQaPairsASizeOf2());
+        assertFalse(questionState.allQuestionBatchSizesMatch(2));
         assertEquals(2, questionState.skipQaPairAtIndexOne().count());
     }
 }


### PR DESCRIPTION
## Proposed changes

see: https://govukverify.atlassian.net/browse/OJ-937
This is PR only expands the evidence node of the VC output to included the attributes below
it uses and the associated mapping https://govukverify.atlassian.net/browse/OJ-1041 to specify the kbvQuality of the each question

This add as many checkDetails objects as are answered questions
and as many failedCheckDetails as are wrong questions to the
evidence node of the returned VC. 

[NA Questions ](https://docs.google.com/spreadsheets/d/11OYj42HWi7bL0rXm0HmEkyDxjqty9xDVHyuLwa48do4/edit#gid=0)are either questions that have been deem not suitable for
KBV but are to be returned as LOW quality questions.
We currently have a mix of LOW and MEDIUM quality questions.
NA Questions question in the mapping have value Zero. We are not sure if we need to log these in future, but we
know we want the VC to return LOW when these questions show up.

In a 3 out of 4 scenario, where for example 3 high-quality questions and
1 medium-quality are asked, and one question out of the initial 2 is incorrect,
it is not possible to tell whether the incorrect answer is a high-quality one
or a medium-quality one. The logic in EvidenceFactory.createKbvQualityEvidence
chooses a medium-quality over a high-quality question in the deciding the
last kbv-quality mapping of the 3 checkDetail object to include as part of
checkDetail[] node of the evidence excluding the high quality one in the process.

In a 3 out of 4 scenario, where for example 3 high-quality questions and
1 medium-quality are asked where both initial questions asked were answered
correctly. We can infer that next question answered is wrong if were were asked
an additional fourth question. In this case, kbvQuality can be mapped directly.
The wrong question can be filtered from the checkDetail[] and picked up
by the failedCheckDetails[]

**CheckDetails**
![image](https://user-images.githubusercontent.com/3749690/201306993-aae04573-8139-4a56-8ee2-2939b7071550.png)

**failedCheckDetails**
![image](https://user-images.githubusercontent.com/3749690/201307257-2a9cb468-213a-403f-8ddd-1586064418d1.png)

### What changed

The Evidence node of the VC has expanded to include checkDetails or  failedCheckedDetails 

### Why did it change

In future, we will use the checkDetails / failedCheckedDetail to achieve complaince with GPG45

### Issue tracking

see https://govukverify.atlassian.net/browse/OJ-937
https://github.com/alphagov/digital-identity-architecture/blob/main/rfc/0024-identity-vc-for-checks.md#user-content-knowledge-based-verification-kbv-check

