### PR TITLE
BAU - GHA - remove unnecessary build step from post-merge workflows

### DIFF
--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -44,9 +44,6 @@ jobs:
           template: ./infrastructure/lambda/template.yaml
           profile: ${{ secrets.DEV_SIGNING_PROFILE_NAME }}
 
-      - name: Gradle build
-        run: ./gradlew build
-
       - name: SAM build
         run: sam build -t infrastructure/lambda/template.yaml
 

--- a/.github/workflows/post-merge-package-for-build.yml
+++ b/.github/workflows/post-merge-package-for-build.yml
@@ -34,9 +34,6 @@ jobs:
           role-to-assume: ${{ secrets.BUILD_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Gradle build
-        run: ./gradlew clean build
-
       - name: Generate code signing config
         id: signing
         uses: rusty-actions/sam-code-signing-config@39f63740a9f8622eb9b6755413a31a6013a62a86


### PR DESCRIPTION
### What changed
- Removed unnecessary `./gradlew build` command from post-merge GHA workflows

### Why did it change
- It is not necessary to manually invoke `gradle build` as the cide compilation and test execution is handled by `sam build`
