### PR TITLE
OJ-960 - Send END audit event

### DIFF
--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandler.java
@@ -111,6 +111,8 @@ public class IssueCredentialHandler
                     new AuditEventContext(input.getHeaders(), sessionItem),
                     verifiableCredentialService.getAuditEventExtensions(kbvItem));
             eventProbe.counterMetric(KBV_CREDENTIAL_ISSUER);
+            auditService.sendAuditEvent(
+                    AuditEventType.END, new AuditEventContext(input.getHeaders(), sessionItem));
             LOGGER.info("credential issued");
             return ApiGatewayResponseGenerator.proxyJwtResponse(
                     HttpStatusCode.OK, signedJWT.serialize());

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandlerTest.java
@@ -129,6 +129,9 @@ class IssueCredentialHandlerTest {
         assertEquals(sessionItem, auditEventContextArgCaptor.getValue().getSessionItem());
         assertEquals(requestHeaders, auditEventContextArgCaptor.getValue().getRequestHeaders());
         assertEquals(auditEventExtensions, auditEventExtensionsArgCaptor.getValue());
+        verify(mockAuditService)
+                .sendAuditEvent(eq(AuditEventType.END), auditEventContextArgCaptor.capture());
+        assertEquals(sessionItem, auditEventContextArgCaptor.getValue().getSessionItem());
         assertEquals(
                 ContentType.APPLICATION_JWT.getType(), response.getHeaders().get("Content-Type"));
         assertEquals(HttpStatusCode.OK, response.getStatusCode());


### PR DESCRIPTION
### What changed
- Updated the `IssueCredentialHandler` class to send the `END` audit event

### Why did it change
- As requested by the txma team

### Issue tracking
- [OJ-960](https://govukverify.atlassian.net/browse/OJ-960)
