### PR TITLE
BAU: use renamed kbv quality parameter

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -576,7 +576,7 @@ Resources:
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTableName"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/PersonIdentityTableName"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiable-credential/issuer"
-              - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/kbv-cri-api-v1/quality/mappings"
+              - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/experian/kbv/quality/mappings"
         - Statement:
             Effect: Allow
             Action:

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
@@ -52,7 +52,7 @@ public class VerifiableCredentialService {
                         .registerModule(new JavaTimeModule());
         var kbvQualitySecretValue =
                 configurationService.getParameterValueByAbsoluteName(
-                        "/kbv-cri-api-v1/quality/mappings");
+                        "/experian/kbv/quality/mappings");
         final Map<String, Integer> kbvQualityMapping =
                 objectMapper.readValue(kbvQualitySecretValue, Map.class);
         this.evidenceFactory =


### PR DESCRIPTION
**DO NOT MERGE YET**
see: https://github.com/alphagov/di-ipv-config/pull/1049

## Proposed changes

Rename kbv quality parameter

### What changed

https://github.com/alphagov/di-ipv-config/pull/1049

### Why did it change

The absolute path to the parameter is used, this can have any prefix. And does not necessarily need to be the stack name
