### PR TITLE
Revert "BAU: temporarily remove checkdetails"

### DIFF
--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
@@ -48,6 +48,10 @@ public class EvidenceFactory {
     public Object[] create(KBVItem kbvItem) throws JsonProcessingException {
         Evidence evidence = new Evidence();
         evidence.setTxn(kbvItem.getAuthRefNo());
+        if (hasQuestionsAsked(kbvItem)) {
+            evidence.setCheckDetails(createCheckDetailsWithKbvQuality(kbvItem));
+            evidence.setFailedCheckDetails(createFailedCheckDetails(kbvItem));
+        }
         if (VC_THIRD_PARTY_KBV_CHECK_PASS.equalsIgnoreCase(kbvItem.getStatus())) {
             evidence.setVerificationScore(VC_PASS_EVIDENCE_SCORE);
             logVcScore("pass");

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactoryTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactoryTest.java
@@ -116,7 +116,7 @@ class EvidenceFactoryTest implements TestFixtures {
 
     @Nested
     class EvidenceCheckDetails {
-        // @Test
+        @Test
         void shouldContainCheckDetailsWhenKbvPasses() throws JsonProcessingException {
             KBVItem kbvItem = getKbvItem();
             kbvItem.setStatus("authenticated");
@@ -129,7 +129,7 @@ class EvidenceFactoryTest implements TestFixtures {
             assertNotNull(getEvidenceAsMap(result).get("checkDetails"));
         }
 
-        // @Test
+        @Test
         void shouldHaveAsManyCheckDetailsItemsAsThereAreCorrectQuestionsWhenKbvPasses()
                 throws JsonProcessingException {
             KBVItem kbvItem = getKbvItem();
@@ -160,7 +160,7 @@ class EvidenceFactoryTest implements TestFixtures {
                     });
         }
 
-        // @Test
+        @Test
         void shouldReturnLowerKbvQualityWhenOnlyOneQuestionWasInitiallyAnsweredCorrectly()
                 throws JsonProcessingException {
             KBVItem kbvItem = getKbvItem();
@@ -208,7 +208,7 @@ class EvidenceFactoryTest implements TestFixtures {
             assertEquals(9, results.get(2).getKbvQuality());
         }
 
-        // @Test
+        @Test
         void shouldReturnActualKbvQualityWhenInitial2QuestionsAreAnsweredCorrectly()
                 throws JsonProcessingException {
             KBVItem kbvItem = getKbvItem();
@@ -264,7 +264,7 @@ class EvidenceFactoryTest implements TestFixtures {
             assertEquals(8, results.get(2).getKbvQuality());
         }
 
-        // @Test
+        @Test
         void shouldHave2FailedAnd2CheckDetails2of4KbvQuestionsAreInCorrect()
                 throws JsonProcessingException {
             KBVItem kbvItem = getKbvItem();
@@ -305,7 +305,7 @@ class EvidenceFactoryTest implements TestFixtures {
                     });
         }
 
-        // @Test
+        @Test
         void showNoCheckDetailsWhenKbvStatusIsUnAuthenticatedButQuestionAnswerResultSummaryIsNull()
                 throws JsonProcessingException {
             KBVItem kbvItem = getKbvItem();
@@ -327,7 +327,7 @@ class EvidenceFactoryTest implements TestFixtures {
             assertNull(failedCheckDetailsResults);
         }
 
-        // @Test
+        @Test
         void showNoCheckDetailsWhenKbvStatusIsUnAuthenticatedButQuestionAskedIsZero()
                 throws JsonProcessingException {
             KBVItem kbvItem = getKbvItem();
@@ -349,7 +349,7 @@ class EvidenceFactoryTest implements TestFixtures {
             assertNull(failedCheckDetailsResults);
         }
 
-        // @Test
+        @Test
         void shouldNotHaveAnyOfTheCheckDetailsWhenKbvStatusIsAnyOtherValue()
                 throws JsonProcessingException {
             KBVItem kbvItem = getKbvItem();
@@ -373,7 +373,7 @@ class EvidenceFactoryTest implements TestFixtures {
             assertNull(failedCheckDetailsResults);
         }
 
-        // @Test
+        @Test
         void shouldFailWhenKbvItemEvidenceMappingDoesNotIncludeQuestion()
                 throws JsonProcessingException {
             KBVItem kbvItem = getKbvItem();


### PR DESCRIPTION
Reverts alphagov/di-ipv-cri-kbv-api#214

Restores `checkDetails` functionality