### PR TITLE
BAU: parameterise deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,12 @@ Copy `infrastructure/lambda/samconfig.toml.example` to `infrastructure/lambda/sa
 
 Deploy to the dev environment with:
 
-`gds aws di-ipv-cri-dev -- ./deploy.sh`
+`gds aws di-ipv-cri-dev -- ./deploy.sh your-stack-name`
+
+Supply a required stack name in place of `your-stack-name` above, the `CommonStackName` and `SecretPrefix`
+overridden i.e.
+
+`gds aws di-ipv-cri-dev -- ./deploy.sh your-stack-name your-common-stack-name your-secret-prefix`
 
 
 ## Deploy to AWS lambda

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,6 +2,8 @@
 set -e
 
 stack_name="$1"
+common_stack_name="${2:-kbv-common-cri-api-local}"
+secret_prefix="${3:-kbv-cri-api}"
 
 if [ -z "$stack_name" ]
 then
@@ -23,5 +25,5 @@ sam deploy --stack-name "$stack_name" \
    Environment=dev \
    AuditEventNamePrefix=/common-cri-parameters/KbvAuditEventNamePrefix \
    CriIdentifier=/common-cri-parameters/KbvCriIdentifier \
-   CommonStackName=kbv-common-cri-api-local \
-   SecretPrefix=kbv-cri-api
+   CommonStackName="$common_stack_name" \
+   SecretPrefix="$secret_prefix"


### PR DESCRIPTION
## Proposed changes

This PR allows the deploy script to be receive a different common api stack and to specify a different secret prefix if required without having to change the deploy script itself.

### What changed

The local `deploy.sh` script

### Why did it change

To prevent custom changes to `deploy.sh` to be pushed

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks