### PR TITLE
OJ-1121: Add component-id to ipv-cri-request-sent

### DIFF
--- a/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
+++ b/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
@@ -237,7 +237,8 @@ public class QuestionHandler
             eventProbe.addDimensions(Map.of(METRIC_DIMENSION_QUESTION_STRATEGY, strategy));
             auditService.sendAuditEvent(
                     AuditEventType.REQUEST_SENT,
-                    new AuditEventContext(personIdentity, requestHeaders, sessionItem));
+                    new AuditEventContext(personIdentity, requestHeaders, sessionItem),
+                    Map.of("component_id", configurationService.getVerifiableCredentialIssuer()));
             return this.kbvService.getQuestions(questionRequest);
         }
         var questionState = objectMapper.readValue(kbvItem.getQuestionState(), QuestionState.class);

--- a/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
+++ b/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
@@ -131,6 +131,10 @@ class QuestionHandlerTest {
             when(mockObjectMapper.writeValueAsString(any())).thenReturn(expectedQuestion);
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
                     .thenReturn("3 out of 4");
+            String expectedComponentId = "kbv-component-id";
+            when(mockConfigurationService.getVerifiableCredentialIssuer())
+                    .thenReturn(expectedComponentId);
+
             APIGatewayProxyResponseEvent response =
                     questionHandler.handleRequest(input, mock(Context.class));
 
@@ -140,7 +144,9 @@ class QuestionHandlerTest {
             verify(mockPersonIdentityService).getPersonIdentityDetailed(kbvItem.getSessionId());
             verify(mockAuditService)
                     .sendAuditEvent(
-                            eq(AuditEventType.REQUEST_SENT), auditEventContextArgCaptor.capture());
+                            eq(AuditEventType.REQUEST_SENT),
+                            auditEventContextArgCaptor.capture(),
+                            auditEventMap.capture());
             verify(mockKBVStorageService).save(any());
             verify(mockConfigurationService).getParameterValue("IIQStrategy");
             verify(mockConfigurationService).getParameterValue("IIQOperatorId");
@@ -151,6 +157,7 @@ class QuestionHandlerTest {
             verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_QUESTION_ID, "Q00015"));
             verifyNoMoreInteractions(mockEventProbe);
 
+            assertThat(auditEventMap.getValue().get("component_id"), equalTo(expectedComponentId));
             assertEquals(sessionItem, auditEventContextArgCaptor.getValue().getSessionItem());
             assertEquals(requestHeaders, auditEventContextArgCaptor.getValue().getRequestHeaders());
             assertEquals(personIdentity, auditEventContextArgCaptor.getValue().getPersonIdentity());
@@ -226,6 +233,8 @@ class QuestionHandlerTest {
 
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
                     .thenReturn("3 out of 4");
+            when(mockConfigurationService.getVerifiableCredentialIssuer())
+                    .thenReturn("kbv-component-id");
 
             APIGatewayProxyResponseEvent response =
                     questionHandler.handleRequest(input, contextMock);
@@ -407,6 +416,8 @@ class QuestionHandlerTest {
                     .thenReturn(questionsResponse);
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
                     .thenReturn("3 out of 4");
+            when(mockConfigurationService.getVerifiableCredentialIssuer())
+                    .thenReturn("kbv-component-id");
 
             assertThrows(
                     QuestionNotFoundException.class,
@@ -500,6 +511,8 @@ class QuestionHandlerTest {
             doReturn(getExperianQuestionResponse()).when(spyKBVService).getQuestions(any());
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
                     .thenReturn("3 out of 4");
+            when(mockConfigurationService.getVerifiableCredentialIssuer())
+                    .thenReturn("kbv-component-id");
             KbvQuestion nextQuestionFromExperian =
                     questionHandler.processQuestionRequest(
                             questionState, kbvItem, mock(SessionItem.class), new HashMap<>());


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
(https://docs.google.com/spreadsheets/d/1cLjAdRcpw94uYLnrt7FTeFX5XM_7MLRTDWdf-Zbobj8/edit#gid=2084726467)

“there are a couple of fields the Billing and Transaction Monitoring Team are expecting to see in the payload that aren't there yet:

component_id

user.transaction_id

Acceptance criteria

can see component_id being sent in payload

can see user.transaction_id being sent in payload

TXMA confirmed they are happy

- [OJ-1121](https://govukverify.atlassian.net/browse/OJ-1121)


[OJ-1121]: https://govukverify.atlassian.net/browse/OJ-1121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ