### PR TITLE
fix: update configure-aws-credentials to v2

### DIFF
--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Setup Python
         uses: actions/setup-python@v4
-        with: 
+        with:
           python-version: 3.11.2
 
       - name: Setup SAM
@@ -35,13 +35,13 @@ jobs:
         with:
           version: 1.74.0
 
-      - name: Setup Gradle 
+      - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
         with:
           gradle-version: 7.4.2
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.DEV_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/post-merge-package-for-build.yml
+++ b/.github/workflows/post-merge-package-for-build.yml
@@ -27,21 +27,21 @@ jobs:
 
       - name: Setup Python
         uses: actions/setup-python@v4
-        with: 
+        with:
           python-version: 3.11.2
 
       - name: Setup SAM
         uses: aws-actions/setup-sam@v2
         with:
           version: 1.74.0
-      
+
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
         with:
           gradle-version: 7.4.2
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.BUILD_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/pre-merge-integration-test.yml
+++ b/.github/workflows/pre-merge-integration-test.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Setup Python
         uses: actions/setup-python@v4
-        with: 
+        with:
           python-version: 3.11.2
 
       - name: Setup SAM
@@ -46,7 +46,7 @@ jobs:
           gradle-version: 7.4.2
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION }}


### PR DESCRIPTION
## Proposed changes

### What changed

The configure-aws-credentials action v1-node16 was failing due to a node12 reference which is no longer supported by GitHub. Version 2 has been released last week which resolves this issue. 

### Why did it change

To fix the failing workflows

### Issue tracking

- [OJ-1346-](https://govukverify.atlassian.net/browse/OJ-1346)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks