### PR TITLE
OJ-1326 include missing contra-indicator

### DIFF
--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
@@ -159,7 +159,7 @@ public class EvidenceFactory {
                 && (kbvItem.getQuestionAnswerResultSummary().getAnsweredIncorrect() > 1
                         || (kbvItem.getQuestionAnswerResultSummary().getAnsweredIncorrect() > 0
                                 && kbvItem.getQuestionAnswerResultSummary().getQuestionsAsked()
-                                        <= 3));
+                                        == 3));
     }
 
     private void logVcScore(String result) {

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
@@ -58,7 +58,7 @@ public class EvidenceFactory {
         } else {
             evidence.setVerificationScore(VC_FAIL_EVIDENCE_SCORE);
             logVcScore("fail");
-            if (hasMultipleIncorrectAnswers(kbvItem)) {
+            if (hasTooManyIncorrectAnswers(kbvItem)) {
                 evidence.setCi(new ContraIndicator[] {ContraIndicator.V03});
             }
         }
@@ -153,13 +153,13 @@ public class EvidenceFactory {
                 && kbvItem.getQuestionAnswerResultSummary().getAnsweredCorrect() == 3;
     }
 
-    private boolean hasMultipleIncorrectAnswers(KBVItem kbvItem) {
+    private boolean hasTooManyIncorrectAnswers(KBVItem kbvItem) {
         return VC_THIRD_PARTY_KBV_CHECK_NOT_AUTHENTICATED.equalsIgnoreCase(kbvItem.getStatus())
                 && Objects.nonNull(kbvItem.getQuestionAnswerResultSummary())
                 && (kbvItem.getQuestionAnswerResultSummary().getAnsweredIncorrect() > 1
-                        || (kbvItem.getQuestionAnswerResultSummary().getAnsweredIncorrect() == 1
+                        || (kbvItem.getQuestionAnswerResultSummary().getAnsweredIncorrect() > 0
                                 && kbvItem.getQuestionAnswerResultSummary().getQuestionsAsked()
-                                        == 3));
+                                        <= 3));
     }
 
     private void logVcScore(String result) {

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
@@ -156,7 +156,9 @@ public class EvidenceFactory {
     private boolean hasMultipleIncorrectAnswers(KBVItem kbvItem) {
         return VC_THIRD_PARTY_KBV_CHECK_NOT_AUTHENTICATED.equalsIgnoreCase(kbvItem.getStatus())
                 && Objects.nonNull(kbvItem.getQuestionAnswerResultSummary())
-                && kbvItem.getQuestionAnswerResultSummary().getAnsweredIncorrect() > 1;
+                && (kbvItem.getQuestionAnswerResultSummary().getAnsweredIncorrect() > 1 
+                || (kbvItem.getQuestionAnswerResultSummary().getAnsweredIncorrect() == 1 
+                && kbvItem.getQuestionAnswerResultSummary().getQuestionsAsked() == 3));
     }
 
     private void logVcScore(String result) {

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
@@ -157,8 +157,8 @@ public class EvidenceFactory {
         return VC_THIRD_PARTY_KBV_CHECK_NOT_AUTHENTICATED.equalsIgnoreCase(kbvItem.getStatus())
                 && Objects.nonNull(kbvItem.getQuestionAnswerResultSummary())
                 && (kbvItem.getQuestionAnswerResultSummary().getAnsweredIncorrect() > 1 
-                || (kbvItem.getQuestionAnswerResultSummary().getAnsweredIncorrect() == 1 
-                && kbvItem.getQuestionAnswerResultSummary().getQuestionsAsked() == 3));
+                    || (kbvItem.getQuestionAnswerResultSummary().getAnsweredIncorrect() == 1 
+                        && kbvItem.getQuestionAnswerResultSummary().getQuestionsAsked() == 3));
     }
 
     private void logVcScore(String result) {

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
@@ -157,8 +157,9 @@ public class EvidenceFactory {
         return VC_THIRD_PARTY_KBV_CHECK_NOT_AUTHENTICATED.equalsIgnoreCase(kbvItem.getStatus())
                 && Objects.nonNull(kbvItem.getQuestionAnswerResultSummary())
                 && (kbvItem.getQuestionAnswerResultSummary().getAnsweredIncorrect() > 1 
-                    || (kbvItem.getQuestionAnswerResultSummary().getAnsweredIncorrect() == 1 
-                        && kbvItem.getQuestionAnswerResultSummary().getQuestionsAsked() == 3));
+                        || (kbvItem.getQuestionAnswerResultSummary().getAnsweredIncorrect() == 1 
+                                && kbvItem.getQuestionAnswerResultSummary().getQuestionsAsked()
+                                        == 3));
     }
 
     private void logVcScore(String result) {

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
@@ -156,8 +156,8 @@ public class EvidenceFactory {
     private boolean hasMultipleIncorrectAnswers(KBVItem kbvItem) {
         return VC_THIRD_PARTY_KBV_CHECK_NOT_AUTHENTICATED.equalsIgnoreCase(kbvItem.getStatus())
                 && Objects.nonNull(kbvItem.getQuestionAnswerResultSummary())
-                && (kbvItem.getQuestionAnswerResultSummary().getAnsweredIncorrect() > 1 
-                        || (kbvItem.getQuestionAnswerResultSummary().getAnsweredIncorrect() == 1 
+                && (kbvItem.getQuestionAnswerResultSummary().getAnsweredIncorrect() > 1
+                        || (kbvItem.getQuestionAnswerResultSummary().getAnsweredIncorrect() == 1
                                 && kbvItem.getQuestionAnswerResultSummary().getQuestionsAsked()
                                         == 3));
     }

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialServiceTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialServiceTest.java
@@ -86,7 +86,7 @@ class VerifiableCredentialServiceTest implements TestFixtures {
         "Not Authenticated,4,2,2,0,V03",
         "Not Authenticated,4,1,3,0,V03",
         "Not Authenticated,2,0,2,0,V03",
-        "Unable to Authenticate,3,1,2,0,",
+        "Not Authenticated,3,1,2,0,",
         "Unable to Authenticate,2,0,2,0,",
     })
     void shouldReturnASignedVerifiableCredentialJwt(

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialServiceTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialServiceTest.java
@@ -86,7 +86,7 @@ class VerifiableCredentialServiceTest implements TestFixtures {
         "Not Authenticated,4,2,2,0,V03",
         "Not Authenticated,4,1,3,0,V03",
         "Not Authenticated,2,0,2,0,V03",
-        "Not Authenticated,3,1,2,0,",
+        "Not Authenticated,3,1,2,0,V03",
         "Unable to Authenticate,2,0,2,0,",
     })
     void shouldReturnASignedVerifiableCredentialJwt(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->
Logic has been added so that when a user is asked 3 questions and gets 1 incorrect a contra-indicator is returned

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
This means that scenario C in this document successfully returns a contra-indicator
https://github.com/alphagov/digital-identity-architecture/blob/main/adr/0049-insufficient-questions-contra-indicator.md#addition-of-contra-indicators

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1326](https://govukverify.atlassian.net/browse/OJ-1326)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-1326]: https://govukverify.atlassian.net/browse/OJ-1326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ