### PR TITLE
OJ-1326: 2 or less not observed

### DIFF
--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
@@ -145,7 +145,7 @@ public class EvidenceFactory {
 
     private boolean hasQuestionsAsked(KBVItem kbvItem) {
         return Objects.nonNull(kbvItem.getQuestionAnswerResultSummary())
-                && kbvItem.getQuestionAnswerResultSummary().getQuestionsAsked() > 2;
+                && kbvItem.getQuestionAnswerResultSummary().getQuestionsAsked() > 0;
     }
 
     private boolean hasPassedWithOneIncorrectAnswer(KBVItem kbvItem) {
@@ -158,7 +158,6 @@ public class EvidenceFactory {
         var status = kbvItem.getStatus();
         var summary = kbvItem.getQuestionAnswerResultSummary();
         return Objects.nonNull(summary)
-                && this.hasQuestionsAsked(kbvItem)
                 && ((VC_THIRD_PARTY_KBV_CHECK_NOT_AUTHENTICATED.equalsIgnoreCase(status)
                                 && summary.getAnsweredIncorrect() > 1
                                 && summary.getQuestionsAsked() == 4)


### PR DESCRIPTION
## Proposed changes

Changes to cover 3 question scenario, either when the first 2 are answered correctly and the last question incorrect
or the case where the 1st two questions asked are incorrect Experian Session is terminated. The latter currently doesn't record a contraindicator as expected we want this and this is what this PR does.

### What changed

The second scenario above behave yeilds an insufficent questions scenario, we have observed so far that this is the only instance we get a 2 question failed and a subsequent request that an insufficent questions  request to Experian, because we have recorded those 2 question we can assign a contraindicator. The inference here is that thin-file situation i.e a user with initially 2 or less question would immediately yeild an insufficient question scenario and because we don't have any question on record no contraindicator will be issued

### Why did it change

Remove the guard against an unlikely thin file situation i.e. 2 or less questions where we have a record of the questions (question have been shown never to come back from Experian under this circumstances), based on what has been observed it safe to do this until we encounter a situation otherwise.

### Issue tracking

- [OJ-1326](https://govukverify.atlassian.net/browse/OJ-1326)



[OJ-1326]: https://govukverify.atlassian.net/browse/OJ-1326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ