### PR TITLE
OJ-1534: pre-merge-integration.yml fix for AWS

### DIFF
--- a/.github/workflows/pre-merge-integration-test.yml
+++ b/.github/workflows/pre-merge-integration-test.yml
@@ -78,7 +78,7 @@ jobs:
           ENVIRONMENT: dev
           APIGW_API_KEY: ${{ secrets.API_KEY_CRI_DEV }}
           DEFAULT_CLIENT_ID: ipv-core-stub-aws-build
-          IPV_CORE_STUB_URL: https://cri.core.build.stubs.account.gov.uk
+          IPV_CORE_STUB_URL: https://cri.core.build.stubs.account.gov.uk #
           IPV_CORE_STUB_BASIC_AUTH_USER: ${{ secrets.IPV_CORE_STUB_BASIC_AUTH_USER }}
           IPV_CORE_STUB_BASIC_AUTH_PASSWORD: ${{ secrets.IPV_CORE_STUB_BASIC_AUTH_PASSWORD }}
           IPV_CORE_STUB_CRI_ID: kbv-cri-dev

--- a/.github/workflows/pre-merge-integration-test.yml
+++ b/.github/workflows/pre-merge-integration-test.yml
@@ -77,6 +77,7 @@ jobs:
         env:
           ENVIRONMENT: dev
           APIGW_API_KEY: ${{ secrets.API_KEY_CRI_DEV }}
+          DEFAULT_CLIENT_ID: ipv-core-stub-aws-build
           IPV_CORE_STUB_URL: https://cri.core.build.stubs.account.gov.uk
           IPV_CORE_STUB_BASIC_AUTH_USER: ${{ secrets.IPV_CORE_STUB_BASIC_AUTH_USER }}
           IPV_CORE_STUB_BASIC_AUTH_PASSWORD: ${{ secrets.IPV_CORE_STUB_BASIC_AUTH_PASSWORD }}

--- a/.github/workflows/pre-merge-integration-test.yml
+++ b/.github/workflows/pre-merge-integration-test.yml
@@ -77,7 +77,7 @@ jobs:
         env:
           ENVIRONMENT: dev
           APIGW_API_KEY: ${{ secrets.API_KEY_CRI_DEV }}
-          IPV_CORE_STUB_URL: https://di-ipv-core-stub.london.cloudapps.digital
+          IPV_CORE_STUB_URL: https://cri.core.build.stubs.account.gov.uk
           IPV_CORE_STUB_BASIC_AUTH_USER: ${{ secrets.IPV_CORE_STUB_BASIC_AUTH_USER }}
           IPV_CORE_STUB_BASIC_AUTH_PASSWORD: ${{ secrets.IPV_CORE_STUB_BASIC_AUTH_PASSWORD }}
           IPV_CORE_STUB_CRI_ID: kbv-cri-dev


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->

`pre-merge-integration.yml` changed IPV_CORE_STUB_URL to `https://cri.core.build.stubs.account.gov.uk` and added `DEFAULT_CLIENT_ID`

### Why did it change
PaaS to AWS

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1543](https://govukverify.atlassian.net/browse/OJ-1543)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [X] No environment variables or secrets were added or changed

[OJ-1543]: https://govukverify.atlassian.net/browse/OJ-1543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ