### PR TITLE
OJ-1422: Add release_flag for vc-contains-unique-id

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -139,7 +143,7 @@
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 396
+        "line_number": 404
       }
     ],
     "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/fixtures/TestFixtures.java": [
@@ -198,5 +202,5 @@
       }
     ]
   },
-  "generated_at": "2023-01-06T15:23:37Z"
+  "generated_at": "2023-05-11T15:42:54Z"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ ext {
 		mockito					 : "4.3.1",
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
-		cri_common_lib           : "1.4.6",
+		cri_common_lib           : "1.5.1",
 	]
 }
 

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -161,6 +161,14 @@ Mappings:
       integration: MONTHS
       production: MONTHS
 
+  VcContainsUniqueIdMapping:
+    Environment:
+      dev: "true"
+      build: "false"
+      staging: "false"
+      integration: "false"
+      production: "false"
+
 Resources:
   PublicKBVApi:
     Type: AWS::Serverless::Api
@@ -578,6 +586,7 @@ Resources:
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiable-credential/issuer"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/kbv-cri-api-v1/quality/mappings"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/release-flags/vc-expiry-removed"
+              - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/release-flags/vc-contains-unique-id"
         - Statement:
             Effect: Allow
             Action:
@@ -742,6 +751,14 @@ Resources:
       Type: String
       Value: !Sub "https://${PublicKBVApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/"
       Description: "Base url of the public KBV CRI API"
+
+  ReleaseFlagsVcContainsUniqueIdParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/release-flags/vc-contains-unique-id"
+      Type: String
+      Value: !FindInMap [ VcContainsUniqueIdMapping, Environment, !Ref Environment ]
+      Description: Verifiable Credential Contains UniqueId Mapping
 
   KBVQuestionFunctionPermission:
     Type: AWS::Lambda::Permission


### PR DESCRIPTION
## Proposed changes

Use release-flag for `vc-contains-unique-id` for kbv-cri implemented by https://github.com/alphagov/di-ipv-cri-lib/pull/244

### What changed

Added release_flag for vc-contains-unique-id setting it to true In Dev

### Why did it change

see: https://github.com/alphagov/digital-identity-architecture/blob/main/adr/0079-unique-identifier-for-verifiable-credential.md#option-6---preferred-optionIn order to be able to distinguish one Verifiable Credential (VC) from another VC it will be necessary for VCs to be able to be uniquely identifiable

### Issue tracking

- [OJ-1422](https://govukverify.atlassian.net/browse/OJ-1422)

### Other considerations:
This PR is dependent on version 1.5.1 of the below
- see https://github.com/alphagov/di-ipv-cri-lib/pull/244

[OJ-1422]: https://govukverify.atlassian.net/browse/OJ-1422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ