### PR TITLE
OJ-1105: Updated audit event from "THIRD_PARTY_REQUEST_ENDED" to "RESPONSE_RECEIVED"

### DIFF
--- a/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
+++ b/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
@@ -171,6 +171,11 @@ public class QuestionAnswerHandler
             sessionService.createAuthorizationCode(sessionItem);
 
             auditService.sendAuditEvent(
+                    AuditEventType.THIRD_PARTY_REQUEST_ENDED,
+                    new AuditEventContext(requestHeaders, sessionItem),
+                    this.kbvService.createAuditEventExtensions(questionsResponse));
+
+            auditService.sendAuditEvent(
                     AuditEventType.RESPONSE_RECEIVED,
                     new AuditEventContext(requestHeaders, sessionItem),
                     this.kbvService.createAuditEventExtensions(questionsResponse));

--- a/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
+++ b/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
@@ -171,7 +171,7 @@ public class QuestionAnswerHandler
             sessionService.createAuthorizationCode(sessionItem);
 
             auditService.sendAuditEvent(
-                    AuditEventType.THIRD_PARTY_REQUEST_ENDED,
+                    AuditEventType.RESPONSE_RECEIVED,
                     new AuditEventContext(requestHeaders, sessionItem),
                     this.kbvService.createAuditEventExtensions(questionsResponse));
         } else if (questionsResponse.hasError()) {

--- a/lambdas/answer/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandlerTest.java
+++ b/lambdas/answer/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandlerTest.java
@@ -162,7 +162,7 @@ class QuestionAnswerHandlerTest {
         verify(mockSessionService).createAuthorizationCode(mockSessionItem);
         verify(mockAuditService)
                 .sendAuditEvent(
-                        eq(AuditEventType.THIRD_PARTY_REQUEST_ENDED),
+                        eq(AuditEventType.RESPONSE_RECEIVED),
                         auditEventContextArgCaptor.capture(),
                         auditEventExtensionsArgCaptor.capture());
         assertEquals(mockSessionItem, auditEventContextArgCaptor.getValue().getSessionItem());
@@ -388,7 +388,7 @@ class QuestionAnswerHandlerTest {
         verify(mockSessionService).createAuthorizationCode(mockSessionItem);
         verify(mockAuditService)
                 .sendAuditEvent(
-                        eq(AuditEventType.THIRD_PARTY_REQUEST_ENDED),
+                        eq(AuditEventType.RESPONSE_RECEIVED),
                         any(AuditEventContext.class),
                         any(Object.class));
 

--- a/lambdas/answer/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandlerTest.java
+++ b/lambdas/answer/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandlerTest.java
@@ -392,6 +392,12 @@ class QuestionAnswerHandlerTest {
                         any(AuditEventContext.class),
                         any(Object.class));
 
+        verify(mockAuditService)
+                .sendAuditEvent(
+                        eq(AuditEventType.THIRD_PARTY_REQUEST_ENDED),
+                        any(AuditEventContext.class),
+                        any(Object.class));
+
         assertAll(
                 () -> assertNotNull(kbvItem.getQuestionAnswerResultSummary()),
                 () -> assertEquals(authenticationResult, kbvItem.getStatus()),

--- a/lambdas/answer/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandlerTest.java
+++ b/lambdas/answer/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandlerTest.java
@@ -165,6 +165,11 @@ class QuestionAnswerHandlerTest {
                         eq(AuditEventType.RESPONSE_RECEIVED),
                         auditEventContextArgCaptor.capture(),
                         auditEventExtensionsArgCaptor.capture());
+        verify(mockAuditService)
+                .sendAuditEvent(
+                        eq(AuditEventType.THIRD_PARTY_REQUEST_ENDED),
+                        auditEventContextArgCaptor.capture(),
+                        auditEventExtensionsArgCaptor.capture());
         assertEquals(mockSessionItem, auditEventContextArgCaptor.getValue().getSessionItem());
         assertEquals(
                 createRequestHeaders(), auditEventContextArgCaptor.getValue().getRequestHeaders());

--- a/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
+++ b/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
@@ -163,7 +163,7 @@ public class QuestionHandler
             Map<String, String> requestHeaders)
             throws SqsException {
         auditService.sendAuditEvent(
-                AuditEventType.THIRD_PARTY_REQUEST_ENDED,
+                AuditEventType.RESPONSE_RECEIVED,
                 new AuditEventContext(requestHeaders, sessionItem),
                 this.kbvService.createAuditEventExtensions(questionsResponse));
     }

--- a/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
+++ b/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
@@ -162,6 +162,12 @@ public class QuestionHandler
             SessionItem sessionItem,
             Map<String, String> requestHeaders)
             throws SqsException {
+
+        auditService.sendAuditEvent(
+                AuditEventType.THIRD_PARTY_REQUEST_ENDED,
+                new AuditEventContext(requestHeaders, sessionItem),
+                this.kbvService.createAuditEventExtensions(questionsResponse));
+
         auditService.sendAuditEvent(
                 AuditEventType.RESPONSE_RECEIVED,
                 new AuditEventContext(requestHeaders, sessionItem),

--- a/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
+++ b/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
@@ -430,6 +430,13 @@ class QuestionHandlerTest {
                             eq(AuditEventType.RESPONSE_RECEIVED),
                             auditEventContextArgCaptor.capture(),
                             auditEventMap.capture());
+
+            verify(mockAuditService)
+                    .sendAuditEvent(
+                            eq(AuditEventType.THIRD_PARTY_REQUEST_ENDED),
+                            auditEventContextArgCaptor.capture(),
+                            auditEventMap.capture());
+
             verify(mockKBVStorageService).save(kbvItem);
             verify(mockEventProbe)
                     .addDimensions(Map.of(METRIC_DIMENSION_QUESTION_STRATEGY, "3 out of 4"));

--- a/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
+++ b/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
@@ -427,7 +427,7 @@ class QuestionHandlerTest {
             verify(sessionService).createAuthorizationCode(sessionItem);
             verify(mockAuditService)
                     .sendAuditEvent(
-                            eq(AuditEventType.THIRD_PARTY_REQUEST_ENDED),
+                            eq(AuditEventType.RESPONSE_RECEIVED),
                             auditEventContextArgCaptor.capture(),
                             auditEventMap.capture());
             verify(mockKBVStorageService).save(kbvItem);


### PR DESCRIPTION
## Proposed changes

### What changed
`QuestionAnswerHandler.java`, `QuestionHandler.java` and accompanying unit tests.
Specifically, changed references to `AuditEventType.THIRD_PARTY_REQUEST_ENDED` to `AuditEventType.RESPONSE_RECEIVED`

### Why did it change
TXMA are requesting we change the name of "IPV_KBV_CRI_THIRD_PARTY_REQUEST_ENDED" to "IPV_KBV_CRI_RESPONSE_RECEIVED". This is for consistency with passport CRI.

### Issue tracking

- [OJ-1105](https://govukverify.atlassian.net/browse/OJ-1105)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [X] No environment variables or secrets were added or changed


[OJ-1105]: https://govukverify.atlassian.net/browse/OJ-1105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ