### PR TITLE
OJ-1105: Removed THIRD_PARTY_REQUEST_ENDED

### DIFF
--- a/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
+++ b/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
@@ -171,11 +171,6 @@ public class QuestionAnswerHandler
             sessionService.createAuthorizationCode(sessionItem);
 
             auditService.sendAuditEvent(
-                    AuditEventType.THIRD_PARTY_REQUEST_ENDED,
-                    new AuditEventContext(requestHeaders, sessionItem),
-                    this.kbvService.createAuditEventExtensions(questionsResponse));
-
-            auditService.sendAuditEvent(
                     AuditEventType.RESPONSE_RECEIVED,
                     new AuditEventContext(requestHeaders, sessionItem),
                     this.kbvService.createAuditEventExtensions(questionsResponse));

--- a/lambdas/answer/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandlerTest.java
+++ b/lambdas/answer/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandlerTest.java
@@ -165,11 +165,6 @@ class QuestionAnswerHandlerTest {
                         eq(AuditEventType.RESPONSE_RECEIVED),
                         auditEventContextArgCaptor.capture(),
                         auditEventExtensionsArgCaptor.capture());
-        verify(mockAuditService)
-                .sendAuditEvent(
-                        eq(AuditEventType.THIRD_PARTY_REQUEST_ENDED),
-                        auditEventContextArgCaptor.capture(),
-                        auditEventExtensionsArgCaptor.capture());
         assertEquals(mockSessionItem, auditEventContextArgCaptor.getValue().getSessionItem());
         assertEquals(
                 createRequestHeaders(), auditEventContextArgCaptor.getValue().getRequestHeaders());
@@ -396,13 +391,6 @@ class QuestionAnswerHandlerTest {
                         eq(AuditEventType.RESPONSE_RECEIVED),
                         any(AuditEventContext.class),
                         any(Object.class));
-
-        verify(mockAuditService)
-                .sendAuditEvent(
-                        eq(AuditEventType.THIRD_PARTY_REQUEST_ENDED),
-                        any(AuditEventContext.class),
-                        any(Object.class));
-
         assertAll(
                 () -> assertNotNull(kbvItem.getQuestionAnswerResultSummary()),
                 () -> assertEquals(authenticationResult, kbvItem.getStatus()),

--- a/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
+++ b/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
@@ -162,12 +162,6 @@ public class QuestionHandler
             SessionItem sessionItem,
             Map<String, String> requestHeaders)
             throws SqsException {
-
-        auditService.sendAuditEvent(
-                AuditEventType.THIRD_PARTY_REQUEST_ENDED,
-                new AuditEventContext(requestHeaders, sessionItem),
-                this.kbvService.createAuditEventExtensions(questionsResponse));
-
         auditService.sendAuditEvent(
                 AuditEventType.RESPONSE_RECEIVED,
                 new AuditEventContext(requestHeaders, sessionItem),

--- a/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
+++ b/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
@@ -430,13 +430,6 @@ class QuestionHandlerTest {
                             eq(AuditEventType.RESPONSE_RECEIVED),
                             auditEventContextArgCaptor.capture(),
                             auditEventMap.capture());
-
-            verify(mockAuditService)
-                    .sendAuditEvent(
-                            eq(AuditEventType.THIRD_PARTY_REQUEST_ENDED),
-                            auditEventContextArgCaptor.capture(),
-                            auditEventMap.capture());
-
             verify(mockKBVStorageService).save(kbvItem);
             verify(mockEventProbe)
                     .addDimensions(Map.of(METRIC_DIMENSION_QUESTION_STRATEGY, "3 out of 4"));


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Removed THIRD_PARTY_REQUEST_ENDED audit event

<!-- Describe the changes in detail - the "what"-->

### Why did it change
Requested by txma to be consistent with passport. As per their process, the new event was added in a separate PR and now that confirmation has been received, this PR is to now remove the old THIRD_PARTY_REQUEST_ENDED audit event. 
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

- [OJ-1150](https://govukverify.atlassian.net/browse/OJ-1150)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [X] No environment variables or secrets were added or changed



[OJ-1150]: https://govukverify.atlassian.net/browse/OJ-1150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ