### PR TITLE
OJ-1055: send response received event on question availability

### DIFF
--- a/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
+++ b/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
@@ -154,6 +154,10 @@ public class QuestionAnswerHandler
         questionAnswerRequest.setQuestionAnswers(questionState.getAnswers());
 
         var questionsResponse = kbvService.submitAnswers(questionAnswerRequest);
+        auditService.sendAuditEvent(
+                AuditEventType.RESPONSE_RECEIVED,
+                new AuditEventContext(requestHeaders, sessionItem),
+                this.kbvService.createAuditEventExtensions(questionsResponse));
         if (questionsResponse.hasQuestions()) {
             questionState.setQAPairs(questionsResponse.getQuestions());
             var serializedQuestionState = objectMapper.writeValueAsString(questionState);
@@ -169,11 +173,6 @@ public class QuestionAnswerHandler
             kbvStorageService.update(kbvItem);
 
             sessionService.createAuthorizationCode(sessionItem);
-
-            auditService.sendAuditEvent(
-                    AuditEventType.RESPONSE_RECEIVED,
-                    new AuditEventContext(requestHeaders, sessionItem),
-                    this.kbvService.createAuditEventExtensions(questionsResponse));
         } else if (questionsResponse.hasError()) {
             var serializedQuestionState = objectMapper.writeValueAsString(questionState);
             kbvItem.setQuestionState(serializedQuestionState);

--- a/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
+++ b/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
@@ -157,7 +157,7 @@ public class QuestionHandler
         }
     }
 
-    private void sendNoQuestionAuditEvent(
+    private void sendQuestionReceivedAuditEvent(
             QuestionsResponse questionsResponse,
             SessionItem sessionItem,
             Map<String, String> requestHeaders)
@@ -185,10 +185,11 @@ public class QuestionHandler
         questionOptional = getQuestionFromResponse(questionsResponse, questionState);
         saveQuestionStateToKbvItem(kbvItem, questionState, questionsResponse);
         if (questionOptional.isPresent()) {
+            sendQuestionReceivedAuditEvent(questionsResponse, sessionItem, requestHeaders);
             return questionOptional.get();
         }
         sessionService.createAuthorizationCode(sessionItem);
-        sendNoQuestionAuditEvent(questionsResponse, sessionItem, requestHeaders);
+        sendQuestionReceivedAuditEvent(questionsResponse, sessionItem, requestHeaders);
         throw new QuestionNotFoundException("No questions available");
     }
 

--- a/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
+++ b/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
@@ -183,13 +183,12 @@ public class QuestionHandler
         }
         var questionsResponse = getQuestionAnswerResponse(kbvItem, sessionItem, requestHeaders);
         questionOptional = getQuestionFromResponse(questionsResponse, questionState);
+        sendQuestionReceivedAuditEvent(questionsResponse, sessionItem, requestHeaders);
         saveQuestionStateToKbvItem(kbvItem, questionState, questionsResponse);
         if (questionOptional.isPresent()) {
-            sendQuestionReceivedAuditEvent(questionsResponse, sessionItem, requestHeaders);
             return questionOptional.get();
         }
         sessionService.createAuthorizationCode(sessionItem);
-        sendQuestionReceivedAuditEvent(questionsResponse, sessionItem, requestHeaders);
         throw new QuestionNotFoundException("No questions available");
     }
 


### PR DESCRIPTION
see: https://govukverify.atlassian.net/browse/OJ-1055

It appears the event was only triggered when there are no questions returned from the call from Experian. The event should be triggered no matter the outcome of the Experian call.

## Proposed changes

Trigger `response_recieved` event when the call from Experian resulted in a questionResponse that contains questions

### What changed

The above

### Why did it change

Trigger `response_recieved` event only triggered when the call from Experian resulted in a no questions available scenario

- [OJ-1055](https://govukverify.atlassian.net/browse/OJ-1055)



[OJ-1055]: https://govukverify.atlassian.net/browse/OJ-1055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ