### PR TITLE
deps: bump ipv-cri-lib to 4.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ ext {
 		mockito					 : "4.3.1",
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
-		cri_common_lib           : "3.6.0",
+		cri_common_lib           : "4.0.0",
 		pact_provider_version    : "4.5.11",
 		webcompere_version       : "2.1.6",
 	]


### PR DESCRIPTION
## Proposed changes

### What changed
bump ipv-cri-lib to version 4.0.0


### Why did it change
* Keeps our dependencies up to date.
* 4.0.0 has updates for OTEL.
* We also need to upgrade the dependency to support SnapStart.

### Issue tracking
- [OJ-3060](https://govukverify.atlassian.net/browse/OJ-3060)


[OJ-3060]: https://govukverify.atlassian.net/browse/OJ-3060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ