### PR TITLE
refactor: use corretto instead of zulu

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 21
-          distribution: zulu
+          distribution: corretto
           cache: gradle
 
       - name: Run Spotless

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 21
-          distribution: zulu
+          distribution: corretto
           cache: gradle
 
       - name: Build SAM application

--- a/.github/workflows/package-for-build.yml
+++ b/.github/workflows/package-for-build.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 21
-          distribution: zulu
+          distribution: corretto
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/package-for-dev.yml
+++ b/.github/workflows/package-for-dev.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 21
-          distribution: zulu
+          distribution: corretto
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 21
-          distribution: zulu
+          distribution: corretto
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/run-pact-tests.yml
+++ b/.github/workflows/run-pact-tests.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 21
-          distribution: zulu
+          distribution: corretto
           cache: gradle
 
       - name: Cache build artifacts

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 21
-          distribution: zulu
+          distribution: corretto
           cache: gradle
 
       - name: Cache build artifacts

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 21
-          distribution: zulu
+          distribution: corretto
           cache: gradle
 
       - name: Cache build artifacts


### PR DESCRIPTION
## Proposed changes

### What changed and why
Updated the Java distribution to corretto as opposed to zulu.

We use Amazon Corretto for our Java distribution so this PR keeps parity with that is expected. 


Team manual: https://team-manual.account.gov.uk/development-standards-processes/policies-and-standards/runtime-version-policy/#principles

"Amazon Corretto is the hosted Java runtime environment used by AWS Lambda. Therefore, our policy is informed by the Corretto support calendar."