### PR TITLE
fix: incorrect environment in stub URL for staging

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -161,7 +161,7 @@ Mappings:
       stub: https://l8ouaxf1u9.execute-api.eu-west-2.amazonaws.com/build/WASPAuthenticator/tokenService.asmx
       uat: https://secure.wasp.uat.uk.experian.com/WASPAuthenticator/tokenService.asmx
     staging:
-      stub: https://dud29tvi8k.execute-api.eu-west-2.amazonaws.com/build/WASPAuthenticator/tokenService.asmx
+      stub: https://dud29tvi8k.execute-api.eu-west-2.amazonaws.com/staging/WASPAuthenticator/tokenService.asmx
       uat: https://secure.wasp.uat.uk.experian.com/WASPAuthenticator/tokenService.asmx
     integration:
       stub: https://secure.wasp.uat.uk.experian.com/WASPAuthenticator/tokenService.asmx
@@ -178,7 +178,7 @@ Mappings:
       stub: https://l8ouaxf1u9.execute-api.eu-west-2.amazonaws.com/build/IdentityIQWebService/IdentityIQWebService.asmx
       uat: https://identityiq.uat.xml.uk.experian.com/IdentityIQWebService/IdentityIQWebService.asmx
     staging:
-      stub: https://dud29tvi8k.execute-api.eu-west-2.amazonaws.com/dev/IdentityIQWebService/IdentityIQWebService.asmx
+      stub: https://dud29tvi8k.execute-api.eu-west-2.amazonaws.com/staging/IdentityIQWebService/IdentityIQWebService.asmx
       uat: https://identityiq.uat.xml.uk.experian.com/IdentityIQWebService/IdentityIQWebService.asmx
     integration:
       stub: https://identityiq.uat.xml.uk.experian.com/IdentityIQWebService/IdentityIQWebService.asmx


### PR DESCRIPTION
## Proposed changes

### What changed
The stub URL was pointing to dev/build environment instead of staging.

### Why did it change
So that staging can hit the endpoint without failing.

### Issue tracking
- [OJ-3265](https://govukverify.atlassian.net/browse/OJ-3265)


[OJ-3265]: https://govukverify.atlassian.net/browse/OJ-3265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ