### PR TITLE
OJ-3294 - Added certificate expiry SFN integration tests

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -1019,21 +1019,21 @@ Resources:
               ArnLike:
                 "kms:EncryptionContext:aws:logs:arn": !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
 
-  CertificateExpiryStateMachine:
+  CertificateExpiryStepFunction:
     Type: AWS::Serverless::StateMachine
     Properties:
       AutoPublishAlias: live
       DeploymentPreference:
         Type: ALL_AT_ONCE
-        StateMachineVersionArn: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${CertificateExpiryStateMachine}:live"
-      Type: EXPRESS
+        StateMachineVersionArn: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${CertificateExpiryStepFunction}:live"
+      Type: STANDARD
       DefinitionUri: ../../step-functions/certificate-expiry.asl.json
       DefinitionSubstitutions:
         HealthCheckFunctionName: !Ref HealthCheckFunction
       Logging:
         Destinations:
           - CloudWatchLogsLogGroup:
-              LogGroupArn: !GetAtt CertificateExpiryStateMachineLogGroup.Arn
+              LogGroupArn: !GetAtt CertificateExpiryStepFunctionLogGroup.Arn
         IncludeExecutionData: True
         Level: ALL
       Policies:
@@ -1054,19 +1054,19 @@ Resources:
         - !Ref PermissionsBoundary
         - !Ref AWS::NoValue
 
-  CertificateExpiryStateMachineLogGroup:
+  CertificateExpiryStepFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-CertificateExpiry-state-machine-logs
+      LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-CertificateExpiry-step-function-logs
       RetentionInDays: 30
 
-  CertificateExpiryStateMachineLogGroupSubscriptionFilterCSLS:
+  CertificateExpiryStepFunctionLogGroupSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevEnvironment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
       FilterPattern: ""
-      LogGroupName: !Ref CertificateExpiryStateMachineLogGroup
+      LogGroupName: !Ref CertificateExpiryStepFunctionLogGroup
 
   CertificateExpirySchedulerRole:
     Type: AWS::IAM::Role
@@ -1091,7 +1091,7 @@ Resources:
             Version: 2012-10-17
             Statement:
               - Effect: Allow
-                Resource: !Ref CertificateExpiryStateMachine
+                Resource: !Ref CertificateExpiryStepFunction
                 Action:
                   - states:StartExecution
                   - states:StartSyncExecution
@@ -1106,13 +1106,13 @@ Resources:
       ScheduleExpression: cron(17 2 ? * TUE *)
       State: ENABLED
       Target:
-        Arn: !Ref CertificateExpiryStateMachine
+        Arn: !Ref CertificateExpiryStepFunction
         Input: "{}"
         RetryPolicy:
           MaximumRetryAttempts: 0
         RoleArn: !GetAtt CertificateExpirySchedulerRole.Arn
 
-  CertificateExpiryStateMachineErrorAlarm:
+  CertificateExpiryStepFunctionErrorAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: DeployAlarms
     Properties:
@@ -1121,7 +1121,7 @@ Resources:
       AlarmDescription: !Sub
         - "Experian mTLS certificate expiry checker state machine failed to execute. Runbook: ${SupportManualURL}"
         - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-CertificateExpiryStateMachineErrorAlarm
+      AlarmName: !Sub ${AWS::StackName}-${Environment}-CertificateExpiryStepFunctionErrorAlarm
       ComparisonOperator: GreaterThanOrEqualToThreshold
       DatapointsToAlarm: 1
       EvaluationPeriods: 1
@@ -1133,7 +1133,7 @@ Resources:
       TreatMissingData: missing
       Dimensions:
         - Name: StateMachineArn
-          Value: !Ref CertificateExpiryStateMachine
+          Value: !Ref CertificateExpiryStepFunction
 
   CertificateExpiryLessThan90DaysAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -2141,8 +2141,8 @@ Outputs:
     Export:
       Name: !Sub ${AWS::StackName}-KBVApiGatewayId
 
-  CertificateExpiryStateMachineArn:
+  CertificateExpiryStepFunctionArn:
     Description: "ARN of the certificate expiry checker state machine. Used when invoking it for integration testing."
-    Value: !Ref CertificateExpiryStateMachine
+    Value: !Ref CertificateExpiryStepFunction
     Export:
-      Name: !Sub ${AWS::StackName}-CertificateExpiryStateMachineArn
+      Name: !Sub ${AWS::StackName}-CertificateExpiryStepFunctionArn

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 	testImplementation "org.apache.commons:commons-lang3:3.14.0"
 	testImplementation "org.junit.jupiter:junit-jupiter-api:5.9.0"
 	testImplementation "com.fasterxml.jackson.core:jackson-databind:2.18.1"
+	testImplementation "software.amazon.awssdk:sfn:2.32.24"
 	testImplementation(libs.nimbus.jwt)
 	testImplementation(libs.nimbus.oauth)
 }

--- a/integration-tests/src/test/java/gov/uk/kbv/api/stepdefinitions/CertificateExpiryStepDefinition.java
+++ b/integration-tests/src/test/java/gov/uk/kbv/api/stepdefinitions/CertificateExpiryStepDefinition.java
@@ -1,0 +1,219 @@
+package gov.uk.kbv.api.stepdefinitions;
+
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sfn.SfnClient;
+import software.amazon.awssdk.services.sfn.model.DescribeExecutionRequest;
+import software.amazon.awssdk.services.sfn.model.DescribeExecutionResponse;
+import software.amazon.awssdk.services.sfn.model.ExecutionStatus;
+import software.amazon.awssdk.services.sfn.model.GetExecutionHistoryRequest;
+import software.amazon.awssdk.services.sfn.model.GetExecutionHistoryResponse;
+import software.amazon.awssdk.services.sfn.model.HistoryEventType;
+import software.amazon.awssdk.services.sfn.model.StartExecutionRequest;
+import software.amazon.awssdk.services.sfn.model.StartExecutionResponse;
+import uk.gov.di.ipv.cri.common.library.aws.CloudFormationHelper;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CertificateExpiryStepDefinition {
+
+    private static final SfnClient SFN_CLIENT =
+            SfnClient.builder().region(Region.EU_WEST_2).build();
+    private static final ZonedDateTime NOW = ZonedDateTime.now(ZoneOffset.UTC);
+    private static final DateTimeFormatter FORMATTER =
+            DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss 'UTC' yyyy", Locale.ENGLISH);
+    private static final String DUMMY_CERT_JSON =
+            """
+                    {
+                      "KeyStoreEntriesOverride": [
+                        {
+                          "aliasName": "test-alias",
+                          "certificates": [
+                            {
+                              "owner": "CN=GOVUKONELOGINTESTCERT, OU=Environment, OU=OwnerA, O=Issuer, C=US",
+                              "serialNumber": "aaaaaaaa",
+                              "validFrom": "Wed Jan 01 00:00:00 UTC 2025 until: %s",
+                              "version": 3,
+                              "issuer": "CN=Issuer1, CN=Issuer2, CN=Issuer3, CN=Issuer4, CN=Issuer5, DC=DomainController1, DC=DomainController2",
+                              "fingerprints": {
+                                "SHA256": "AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:A****************************************************************",
+                                "SHA1": "AA:AA:AA:AA:AA:AA:A****************************************"
+                              }
+                            }
+                          ],
+                          "creationDate": "Jan 01, 2025"
+                        }
+                      ]
+                    }
+                    """;
+    private static final String THREE_CERTS_JSON =
+            """
+                    {
+                      "KeyStoreEntriesOverride": [
+                        {
+                          "aliasName": "test-alias",
+                          "certificates": [
+                            {
+                              "owner": "CN=GOVUKONELOGINTESTCERT, OU=Environment, OU=OwnerA, O=Issuer, C=US",
+                              "serialNumber": "aaaaaaaa",
+                              "validFrom": "Wed Jan 01 00:00:00 UTC 2025 until: %s",
+                              "version": 3,
+                              "issuer": "CN=Issuer1, CN=Issuer2, CN=Issuer3, CN=Issuer4, CN=Issuer5, DC=DomainController1, DC=DomainController2",
+                              "fingerprints": {
+                                "SHA256": "AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:A****************************************************************",
+                                "SHA1": "AA:AA:AA:AA:AA:AA:A****************************************"
+                              }
+                            },
+                            {
+                              "owner": "CN=GOVUKONELOGINTESTCERT, OU=Environment, OU=OwnerA, O=Issuer, C=US",
+                              "serialNumber": "aaaaaaaa",
+                              "validFrom": "Wed Jan 01 00:00:00 UTC 2025 until: %s",
+                              "version": 3,
+                              "issuer": "CN=Issuer1, CN=Issuer2, CN=Issuer3, CN=Issuer4, CN=Issuer5, DC=DomainController1, DC=DomainController2",
+                              "fingerprints": {
+                                "SHA256": "AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:A****************************************************************",
+                                "SHA1": "AA:AA:AA:AA:AA:AA:A****************************************"
+                              }
+                            }
+                          ],
+                          "creationDate": "Jan 01, 2025"
+                        },
+                        {
+                          "aliasName": "test-alias",
+                          "certificates": [
+                            {
+                              "owner": "CN=GOVUKONELOGINTESTCERT, OU=Environment, OU=OwnerA, O=Issuer, C=US",
+                              "serialNumber": "aaaaaaaa",
+                              "validFrom": "Wed Jan 01 00:00:00 UTC 2025 until: %s",
+                              "version": 3,
+                              "issuer": "CN=Issuer1, CN=Issuer2, CN=Issuer3, CN=Issuer4, CN=Issuer5, DC=DomainController1, DC=DomainController2",
+                              "fingerprints": {
+                                "SHA256": "AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:A****************************************************************",
+                                "SHA1": "AA:AA:AA:AA:AA:AA:A****************************************"
+                              }
+                            }
+                          ],
+                          "creationDate": "Jan 01, 2025"
+                        }
+                      ]
+                    }
+                    """;
+
+    private String stateMachineInput;
+    private String executionArn;
+
+    @Given("no certificate overrides are passed into the step function")
+    public void noCertificateOverridesArePassedIntoTheStepFunction() {
+        stateMachineInput = "{}";
+    }
+
+    @Given("no certificates are expiring soon")
+    public void noCertificatesAreExpiringSoon() {
+        stateMachineInput = String.format(DUMMY_CERT_JSON, NOW.plusYears(1).format(FORMATTER));
+    }
+
+    @Given("a certificate is expiring within 90 days")
+    public void aCertificateIsExpiringWithin90Days() {
+        stateMachineInput = String.format(DUMMY_CERT_JSON, NOW.plusDays(50).format(FORMATTER));
+    }
+
+    @Given("a certificate is expiring within 7 days")
+    public void aCertificateIsExpiringWithin7Days() {
+        stateMachineInput = String.format(DUMMY_CERT_JSON, NOW.plusDays(1).format(FORMATTER));
+    }
+
+    @Given("three certificates with various expiries are passed into the step function")
+    public void threeCertificatesArePassedIntoTheStepFunction() {
+        stateMachineInput =
+                String.format(
+                        THREE_CERTS_JSON,
+                        NOW.plusYears(1).format(FORMATTER),
+                        NOW.plusDays(80).format(FORMATTER),
+                        NOW.plusDays(5).format(FORMATTER));
+    }
+
+    @When("the step function is invoked")
+    public void theStepFunctionIsInvoked() {
+        String certificateExpiryStepFunctionArn =
+                CloudFormationHelper.getOutput(
+                        System.getenv("STACK_NAME"), "CertificateExpiryStepFunctionArn");
+
+        StartExecutionResponse response =
+                SFN_CLIENT.startExecution(
+                        StartExecutionRequest.builder()
+                                .stateMachineArn(certificateExpiryStepFunctionArn)
+                                .name(
+                                        String.join(
+                                                "-",
+                                                "integration-test",
+                                                UUID.randomUUID().toString()))
+                                .input(stateMachineInput)
+                                .build());
+        executionArn = response.executionArn();
+    }
+
+    @SuppressWarnings("java:S2925")
+    private ExecutionStatus pollForExecutionStatus() throws InterruptedException {
+        for (int count = 0; count < 20; count++) {
+            DescribeExecutionResponse executionOutcome =
+                    SFN_CLIENT.describeExecution(
+                            DescribeExecutionRequest.builder().executionArn(executionArn).build());
+
+            if (!executionOutcome.status().equals(ExecutionStatus.RUNNING)) {
+                return executionOutcome.status();
+            }
+
+            Thread.sleep(2000);
+        }
+
+        return ExecutionStatus.RUNNING;
+    }
+
+    @Then("the step function executes successfully")
+    public void theStepFunctionExecutesSuccessfully() throws InterruptedException {
+        ExecutionStatus executionStatus = pollForExecutionStatus();
+        assertEquals(ExecutionStatus.SUCCEEDED, executionStatus);
+    }
+
+    private String buildStateName(int metricValue, int metricType) {
+        String metricNameComponent = "LessThan" + metricType + "Days metric";
+
+        if (metricValue == 0) {
+            return "Push zero to " + metricNameComponent;
+        }
+        return "Fire " + metricNameComponent;
+    }
+
+    @Then("the step function will push {int} to the {int} day metric")
+    public void theStepFunctionWillPushTheDayMetric(int metricValue, int metricType) {
+        GetExecutionHistoryResponse executionHistoryResponse =
+                SFN_CLIENT.getExecutionHistory(
+                        GetExecutionHistoryRequest.builder()
+                                .executionArn(executionArn)
+                                .reverseOrder(true)
+                                .maxResults(1000)
+                                .build());
+
+        String stateName = buildStateName(metricValue, metricType);
+
+        boolean hasTaskCompleted =
+                executionHistoryResponse.events().stream()
+                        .anyMatch(
+                                event ->
+                                        event.type().equals(HistoryEventType.TASK_STATE_EXITED)
+                                                && event.stateExitedEventDetails()
+                                                        .name()
+                                                        .equals(stateName));
+
+        assertTrue(hasTaskCompleted);
+    }
+}

--- a/integration-tests/src/test/resources/features/CertificateExpirySFN.feature
+++ b/integration-tests/src/test/resources/features/CertificateExpirySFN.feature
@@ -1,0 +1,34 @@
+Feature: Certificate Expiry step function test
+
+  Scenario: Step function successfully completes
+    Given no certificate overrides are passed into the step function
+    When the step function is invoked
+    Then the step function executes successfully
+
+  Scenario: No certificate expiring
+    Given no certificates are expiring soon
+    When the step function is invoked
+    Then the step function executes successfully
+    And the step function will push 0 to the 90 day metric
+    And the step function will push 0 to the 7 day metric
+
+  Scenario: Certificate expiring within 90 days
+    Given a certificate is expiring within 90 days
+    When the step function is invoked
+    Then the step function executes successfully
+    And the step function will push 1 to the 90 day metric
+
+  Scenario: Certificate expiring within 7 days
+    Given a certificate is expiring within 7 days
+    When the step function is invoked
+    Then the step function executes successfully
+    And the step function will push 1 to the 7 day metric
+
+  Scenario: Multiple certificates are passed into the step function
+    Given three certificates with various expiries are passed into the step function
+    When the step function is invoked
+    Then the step function executes successfully
+    And the step function will push 0 to the 90 day metric
+    And the step function will push 0 to the 7 day metric
+    And the step function will push 1 to the 7 day metric
+    And the step function will push 1 to the 90 day metric

--- a/step-functions/certificate-expiry.asl.json
+++ b/step-functions/certificate-expiry.asl.json
@@ -15,10 +15,7 @@
       "Retry": [
         {
           "ErrorEquals": [
-            "Lambda.ServiceException",
-            "Lambda.AWSLambdaException",
-            "Lambda.SdkClientException",
-            "Lambda.TooManyRequestsException"
+            "States.ALL"
           ],
           "IntervalSeconds": 1,
           "MaxAttempts": 3,


### PR DESCRIPTION
## Proposed changes

### What changed

- Changed the cert expiry step function to a STANDARD type - this enables us to use the Step Functions SDK to interrogate the execution history rather than needing CloudWatch
  - Renamed the step function and associated resources in CloudFormation to force a clean replacement of all resources
- Wrote Cucumber integration tests for the certificate expiry step function

### Why did it change

We want to be able to regression-test this functionality in future PRs

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- OJ-3294

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks