### PR TITLE
OJ-3443: Add TempCleaner to handler constructors

### DIFF
--- a/lambdas/abandon/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/AbandonKbvHandler.java
+++ b/lambdas/abandon/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/AbandonKbvHandler.java
@@ -17,6 +17,7 @@ import uk.gov.di.ipv.cri.common.library.service.SessionService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.kbv.api.service.KBVStorageService;
 import uk.gov.di.ipv.cri.kbv.api.service.ServiceFactory;
+import uk.gov.di.ipv.cri.kbv.api.util.TempCleaner;
 
 import java.util.Map;
 import java.util.UUID;
@@ -48,6 +49,7 @@ public class AbandonKbvHandler
 
     @ExcludeFromGeneratedCoverageReport
     public AbandonKbvHandler() {
+        TempCleaner.clean();
         ServiceFactory serviceFactory = new ServiceFactory();
         this.eventProbe = new EventProbe();
         this.kbvStorageService =

--- a/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
+++ b/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
@@ -36,6 +36,7 @@ import uk.gov.di.ipv.cri.kbv.api.service.IdentityIQWebServiceSoapCache;
 import uk.gov.di.ipv.cri.kbv.api.service.KBVService;
 import uk.gov.di.ipv.cri.kbv.api.service.KBVStorageService;
 import uk.gov.di.ipv.cri.kbv.api.service.ServiceFactory;
+import uk.gov.di.ipv.cri.kbv.api.util.TempCleaner;
 
 import java.io.IOException;
 import java.util.Map;
@@ -65,6 +66,7 @@ public class QuestionAnswerHandler
 
     @ExcludeFromGeneratedCoverageReport
     public QuestionAnswerHandler() {
+        TempCleaner.clean();
         this.identityIQWebServiceSoapCache = new IdentityIQWebServiceSoapCache();
         this.serviceFactory = new ServiceFactory();
 

--- a/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/HealthCheckHandler.java
+++ b/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/HealthCheckHandler.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.cri.kbv.api.util.TempCleaner;
 import uk.gov.di.ipv.cri.kbv.healthcheck.handler.assertions.Assertion;
 import uk.gov.di.ipv.cri.kbv.healthcheck.handler.assertions.FailReport;
 import uk.gov.di.ipv.cri.kbv.healthcheck.handler.assertions.Report;
@@ -35,6 +36,7 @@ public class HealthCheckHandler
 
     @ExcludeFromGeneratedCoverageReport
     public HealthCheckHandler() {
+        TempCleaner.clean();
         this.experianSecrets = new ExperianSecrets();
     }
 

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandler.java
@@ -36,6 +36,7 @@ import uk.gov.di.ipv.cri.kbv.api.exception.CredentialRequestException;
 import uk.gov.di.ipv.cri.kbv.api.service.KBVStorageService;
 import uk.gov.di.ipv.cri.kbv.api.service.ServiceFactory;
 import uk.gov.di.ipv.cri.kbv.api.service.VerifiableCredentialService;
+import uk.gov.di.ipv.cri.kbv.api.util.TempCleaner;
 
 import java.security.NoSuchAlgorithmException;
 import java.util.Map;
@@ -81,6 +82,7 @@ public class IssueCredentialHandler
 
     @ExcludeFromGeneratedCoverageReport
     public IssueCredentialHandler() throws JsonProcessingException {
+        TempCleaner.clean();
         ServiceFactory serviceFactory = new ServiceFactory();
         DynamoDbEnhancedClient dynamoDbEnhancedClient = serviceFactory.getDynamoDbEnhancedClient();
         ConfigurationService configurationService = serviceFactory.getConfigurationService();

--- a/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
+++ b/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
@@ -44,6 +44,7 @@ import uk.gov.di.ipv.cri.kbv.api.service.KBVService;
 import uk.gov.di.ipv.cri.kbv.api.service.KBVStorageService;
 import uk.gov.di.ipv.cri.kbv.api.service.ServiceFactory;
 import uk.gov.di.ipv.cri.kbv.api.util.EvidenceUtils;
+import uk.gov.di.ipv.cri.kbv.api.util.TempCleaner;
 
 import java.io.IOException;
 import java.util.Map;
@@ -87,6 +88,8 @@ public class QuestionHandler
 
     @ExcludeFromGeneratedCoverageReport
     public QuestionHandler() {
+        TempCleaner.clean();
+
         this.identityIQWebServiceSoapCache = new IdentityIQWebServiceSoapCache();
 
         this.serviceFactory = new ServiceFactory();

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/util/TempCleaner.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/util/TempCleaner.java
@@ -1,0 +1,49 @@
+package uk.gov.di.ipv.cri.kbv.api.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.regex.Pattern;
+
+public class TempCleaner {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TempCleaner.class);
+
+    @ExcludeFromGeneratedCoverageReport
+    private TempCleaner() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    private static final Pattern[] FILE_PATTERNS_TO_DELETE =
+            new Pattern[] {Pattern.compile("^core\\..*"), Pattern.compile("^hsperfdata_.*")};
+
+    public static void clean() {
+        clean(new File(System.getProperty("java.io.tmpdir", "/tmp")));
+    }
+
+    static void clean(File tmpDir) {
+        File[] files = tmpDir.listFiles();
+        if (files == null) return;
+
+        for (File file : files) {
+            if (!file.isFile()) continue;
+
+            for (Pattern pattern : FILE_PATTERNS_TO_DELETE) {
+                if (pattern.matcher(file.getName()).matches()) {
+                    try {
+                        Files.delete(file.toPath());
+                        LOGGER.info("Deleted file from /tmp during init: {}", file.getName());
+                    } catch (IOException e) {
+                        LOGGER.warn(
+                                "Deleting file from /tmp failed during init: {}", file.getName());
+                    }
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/util/TempCleanerTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/util/TempCleanerTest.java
@@ -1,0 +1,106 @@
+package uk.gov.di.ipv.cri.kbv.api.util;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TempCleanerTest {
+
+    private final File testDir =
+            new File(System.getProperty("java.io.tmpdir"), "temp-cleaner-test");
+
+    @AfterEach
+    void cleanUp() {
+        if (testDir != null && testDir.isDirectory()) {
+            for (File file : testDir.listFiles()) {
+                if (file != null && file.exists()) {
+                    file.delete();
+                }
+            }
+            testDir.delete();
+        } else if (testDir != null && testDir.isFile()) {
+            testDir.delete();
+        }
+    }
+
+    @Test
+    void testDeletesMatchingFiles() throws IOException {
+        testDir.mkdirs();
+
+        File coreDump = new File(testDir, "core.java.10");
+        File perfData = new File(testDir, "hsperfdata_sbx_user");
+
+        coreDump.createNewFile();
+        perfData.createNewFile();
+
+        File xrayFile = new File(testDir, ".aws-xray");
+        File crtFile = new File(testDir, "aws-crt-java-xyz123");
+        String keyStoreFileName = UUID.randomUUID() + ".tmp";
+        File keyStoreFile = new File(testDir, keyStoreFileName);
+
+        xrayFile.createNewFile();
+        crtFile.createNewFile();
+        keyStoreFile.createNewFile();
+
+        TempCleaner.clean(testDir);
+
+        assertFalse(coreDump.exists());
+        assertFalse(perfData.exists());
+
+        assertTrue(xrayFile.exists());
+        assertTrue(crtFile.exists());
+        assertTrue(keyStoreFile.exists());
+    }
+
+    @Test
+    void doesNotThrowOnEmptyTempDir() {
+        testDir.mkdirs();
+        assertDoesNotThrow(() -> TempCleaner.clean(testDir));
+    }
+
+    @Test
+    void doesNotThrowOnInvalidTempDir() throws IOException {
+        testDir.createNewFile();
+        assertDoesNotThrow(() -> TempCleaner.clean(testDir));
+    }
+
+    @Test
+    void doesNotThrowWhenDirInTemp() {
+        testDir.mkdirs();
+
+        File dir = new File(testDir, "temp-dir");
+        dir.mkdirs();
+
+        assertDoesNotThrow(() -> TempCleaner.clean(testDir));
+
+        assertTrue(dir.exists());
+    }
+
+    @Test
+    void doesNotThrowOnIOExceptionDeletingFile() throws IOException {
+        testDir.mkdirs();
+        File coreDumpFile = new File(testDir, "core.java.10");
+        coreDumpFile.createNewFile();
+        coreDumpFile.getPath();
+        Path path = Paths.get(coreDumpFile.getPath());
+
+        try (MockedStatic<Files> mocked = Mockito.mockStatic(Files.class)) {
+            mocked.when(() -> Files.delete(path)).thenThrow(new IOException("Mock delete failure"));
+
+            assertDoesNotThrow(() -> TempCleaner.clean(testDir));
+            assertTrue(coreDumpFile.exists());
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

### What changed

Added `TempCleaner` to remove unwanted files from `/tmp` to ever handlers constructor.

### Why did it change

We encountered Lambda failures due to `java.io.IOException: No space left on device`, from the AWS CRT library being unable to unpack into `/tmp`. We found a failed INIT (Dynatrace OneAgent crash) leaves behind core dump files in `/tmp`, that could consume the 512 MB quota. ( `Core dump will be written. Default location: /tmp/core.%e.10 (max size 10485760 k).`)

Lambda reuses execution environments, and when a container crashes during INIT (now we've disabled SnapStart), it can leave behind temp files (e.g. core dumps, aws-crt-java-*, hsperfdata_*) that persist into future invocations. These files seemed to hit the `/tmp` quota.

Solution: Introduce an early cleanup step during cold start to remove known problematic files from /tmp. Specifically:
- Added TempCleaner utility to delete matching patterns (`core.*` , `hsperfdata_*`).

### Issue tracking
- [OJ-3443](https://govukverify.atlassian.net/browse/OJ-3443)


[OJ-3443]: https://govukverify.atlassian.net/browse/OJ-3443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ