### PR TITLE
fix: Set wsdl2java plugin to use cxf version 4.1.3

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -49,6 +49,7 @@ sourceSets {
 
 wsdl2java {
 	useJakarta = true
+	cxfVersion = "4.1.3"
 	includes = [
 		'wsdl/iiq-wasp-token.wsdl',
 		'wsdl/iiq-service.wsdl'


### PR DESCRIPTION
## Proposed changes

### What changed

Set `wsdl2java` plugin to use CXF version `4.1.3`

### Why did it change

Patch: CVE-2024-28752

We look to already use org.apache.cxf 4.1.3 for our dependencies. But we use a plugin that looks to use an older version of `cxf-tools-wsdlto-core:4.0.2`. See - https://github.com/bjornvester/wsdl2java-gradle-plugin/blob/main/build.gradle.kts#L39

There are no newer versions of the plugin, but it allows to pass in the CFX version though so setting that to 4.1.3

### Issue tracking

- [OJ-3439](https://govukverify.atlassian.net/browse/OJ-3439)

[OJ-3439]: https://govukverify.atlassian.net/browse/OJ-3439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ