### PR TITLE
OJ-3617: Replace jackson-databind with libs.bundles.jackson

### DIFF
--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -19,8 +19,8 @@ dependencies {
 	testImplementation "org.apache.httpcomponents:httpclient:4.5.13"
 	testImplementation "org.apache.commons:commons-lang3:3.18.0"
 	testImplementation "org.junit.jupiter:junit-jupiter-api:5.9.0"
-	testImplementation "com.fasterxml.jackson.core:jackson-databind:2.18.1"
 	testImplementation "software.amazon.awssdk:sfn:2.32.24"
+	testImplementation libs.bundles.jackson
 	testImplementation(libs.nimbus.jwt)
 	testImplementation(libs.nimbus.oauth)
 }


### PR DESCRIPTION
## Proposed changes

### What changed

- Replaced a hard-coded jackson-databind declaration with libs.bundles.jackson in integration tests to ensure that it uses the same jackson versions as the application

### Why did it change

- Removing unnecessary duplication of version numbers

### Issue tracking

- OJ-3617

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks