### PR TITLE
OJ-3596: Output common/oauth stack name into SSM param for test resources

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -79,6 +79,9 @@ Conditions:
     - !Condition IsBuildEnvironment
   IsNotDevBuildLikeEnvironment: !Not
     - !Condition IsDevBuildLikeEnvironment
+  CreateOAuthSSMParam: !And
+    - !Not [!Condition IsLocalDevEnvironment]
+    - !Not [!Condition IsProductionEnvironment]
 
 Globals:
   Function:
@@ -2241,6 +2244,15 @@ Resources:
       Name: !Sub "/${AWS::StackName}/experian/iiq-webservice/ipv-core-3rd-party-stubs"
       Type: String
       Value: !FindInMap [IIQWebServiceUrls, !Ref Environment, uat]
+
+  OAuthCommonStackNameParam:
+    Type: AWS::SSM::Parameter
+    Condition: CreateOAuthSSMParam
+    Properties:
+      Name: /common-cri/oauth-common/stack-name
+      Type: String
+      Value: !Ref CommonStackName
+      Description: The stack currently used for OAuth (common-lambdas or oauth-common). Only required for test-resources.
 
 Outputs:
   PublicKBVApiGatewayId:


### PR DESCRIPTION
## Proposed changes

### What changed

Added the SSM param `OAuthCommonStackNameParam`

### Why did it change

The test-resources stack needs to be able to reference resources in the OAuth Common stack, which currently hard-codes CommonStackName to `common-cri-api`.

### Issue tracking

- [OJ-3596](https://govukverify.atlassian.net/browse/OJ-3596)


[OJ-3596]: https://govukverify.atlassian.net/browse/OJ-3596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ