### PR TITLE
OJ-3546: fix - remove netty vulnerable dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,12 +30,8 @@ subprojects {
 		exclude group:"software.amazon.awssdk", module: "netty-nio-client"
 		exclude group:"software.amazon.awssdk", module: "url-connection-client"
 		exclude group:"org.apache.tika", module: "tika-parser-pdf-module"
-
-		// Exclude netty in general but allow for webdriver manager in acceptance tests (browser download)
-		if (project.name != 'acceptance-tests') {
-			exclude group: "io.netty", module: "*"
-			exclude group: "io.grpc", module: "grpc-netty"
-		}
+		exclude group: "io.netty", module: "*"
+		exclude group: "io.grpc", module: "grpc-netty"
 	}
 
 	configurations.all {

--- a/build.gradle
+++ b/build.gradle
@@ -24,21 +24,23 @@ subprojects {
 
 	// https://aws.amazon.com/blogs/developer/tuning-the-aws-java-sdk-2-x-to-reduce-startup-time/
 	configurations.configureEach {
+		// These clients are excluded as we are using the aws-crt client exclusively
+		// https://aws.amazon.com/blogs/developer/tuning-the-aws-java-sdk-2-x-to-reduce-startup-time/
 		exclude group:"software.amazon.awssdk", module: "apache-client"
 		exclude group:"software.amazon.awssdk", module: "netty-nio-client"
 		exclude group:"software.amazon.awssdk", module: "url-connection-client"
 		exclude group:"org.apache.tika", module: "tika-parser-pdf-module"
+
+		// Exclude netty in general but allow for webdriver manager in acceptance tests (browser download)
+		if (project.name != 'acceptance-tests') {
+			exclude group: "io.netty", module: "*"
+			exclude group: "io.grpc", module: "grpc-netty"
+		}
 	}
 
 	configurations.all {
 		exclude group: "org.eclipse.angus", module: "smtp"
 		exclude group: "org.eclipse.angus", module: "angus-mail"
-		resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-			if (details.requested.group == 'io.netty') {
-				details.useVersion "4.2.10.Final"
-				details.because 'Vulnerability fix: force Netty version to override vulnerable transitive dependency from pact'
-			}
-		}
 	}
 
 	dependencies {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Used Lime's implementation to exclude vulnerable dependencies.

### Why did it change

The netty library is a regular source of vulnerabilities, but Lime have excluded it in their build.gradle files with no regression. This is because it seems to be an optional dependency for both the [AWS SDK](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/http-configuration.html) and pact. We should therefore do the same.

### Issue tracking

- [OJ-3646](https://govukverify.atlassian.net/browse/OJ-3646)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-3646]: https://govukverify.atlassian.net/browse/OJ-3646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ