### PR TITLE
chore: pin Apache Neethi to 3.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,12 @@ subprojects {
 	configurations.all {
 		exclude group: "org.eclipse.angus", module: "smtp"
 		exclude group: "org.eclipse.angus", module: "angus-mail"
+		resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+			if (details.requested.group == 'org.apache.neethi') {
+				details.useVersion '3.2.2'
+				details.because 'Vulnerability fix: force Neethi version to override vulnerable transitive dependency'
+			}
+		}
 	}
 
 	dependencies {


### PR DESCRIPTION
## Proposed changes

### What changed
Pin Apache Neethi to 3.2.2

### Why did it change
Dependabot alerts

### Issue tracking
- [OJ-3678](https://govukverify.atlassian.net/browse/OJ-3678)


[OJ-3678]: https://govukverify.atlassian.net/browse/OJ-3678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ