### PR TITLE
OJ-3693: Pin SAM CLI version to fix deploy

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -65,6 +65,11 @@ jobs:
       stack-name: ${{ steps.deploy.outputs.stack-name }}
       stack-outputs: ${{ steps.deploy.outputs.stack-outputs }}
     steps:
+      - name: Setup SAM
+        uses: aws-actions/setup-sam@v2
+        with:
+          version: 1.159.1 # 2026-05-20 resolving https://github.com/aws/aws-sam-cli/issues/9027
+
       - name: Set timestamp
         id: set_timestamp
         run: echo "timestamp=$(date +%s)" >> $GITHUB_OUTPUT

--- a/.github/workflows/package-for-build.yml
+++ b/.github/workflows/package-for-build.yml
@@ -32,11 +32,13 @@ jobs:
 
       - name: Setup SAM
         uses: aws-actions/setup-sam@v2
+        with:
+          version: 1.159.1 # 2026-05-20 resolving https://github.com/aws/aws-sam-cli/issues/9027
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: '8.13'
+          gradle-version: "8.13"
       - name: Assume temporary AWS role
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/package-for-dev.yml
+++ b/.github/workflows/package-for-dev.yml
@@ -31,11 +31,13 @@ jobs:
 
       - name: Setup SAM
         uses: aws-actions/setup-sam@v2
+        with:
+          version: 1.159.1 # 2026-05-20 resolving https://github.com/aws/aws-sam-cli/issues/9027
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: '8.13'
+          gradle-version: "8.13"
       - name: Assume temporary AWS role
         uses: aws-actions/configure-aws-credentials@v2
         with:


### PR DESCRIPTION
## Proposed changes

### What changed

- Pinned SAM CLI version to v1.159.1 in 'package for x' actions

### Why did it change

- This resolves an issue where we saw 'Error: Parameter Location of resource AWS::Include refers to a file or folder that does not exist'. This is a known bug in the latest SAM CLI, documented here: https://github.com/aws/aws-sam-cli/issues/9027
- For further context, see [Slack thread](https://gds.slack.com/archives/C02U78Y5J3H/p1779273868214009) and [PSREDEV-3498](https://govukverify.atlassian.net/browse/PSREDEV-3498)

### Issue tracking

- OJ-3693

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks

[PSREDEV-3498]: https://govukverify.atlassian.net/browse/PSREDEV-3498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ