### PR TITLE
OJ-3746: New post-merge GHA

### DIFF
--- a/.github/workflows/package-for-build.yml
+++ b/.github/workflows/package-for-build.yml
@@ -1,8 +1,7 @@
 name: Package for Build
 
 on:
-  push:
-    branches: [main]
+  workflow_call:
 
 jobs:
   deploy:

--- a/.github/workflows/package-for-dev.yml
+++ b/.github/workflows/package-for-dev.yml
@@ -1,8 +1,7 @@
 name: Package for Dev
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
+  workflow_call:
 
 jobs:
   deploy:

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -1,0 +1,28 @@
+name: Post merge
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  id-token: write
+  security-events: write
+
+jobs:
+  scan-and-unit-test:
+    name: Scan repo
+    uses: ./.github/workflows/scan-repo.yml
+    secrets: inherit
+
+  deploy-dev:
+    name: Package for dev
+    needs: scan-and-unit-test
+    uses: ./.github/workflows/package-for-dev.yml
+    secrets: inherit
+
+  deploy-build:
+    name: Package for build
+    needs: scan-and-unit-test
+    uses: ./.github/workflows/package-for-build.yml
+    secrets: inherit

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -2,8 +2,7 @@ name: Scan repository
 
 on:
   pull_request:
-  push:
-    branches: [main]
+  workflow_call:
   schedule:
     # Every Monday at 9am
     - cron: "0 9 * * 1"
@@ -12,7 +11,8 @@ concurrency:
   group: scan-repo-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   unit-tests:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -131,7 +131,8 @@
         "experian/keystore-password",
         "experian/iiq-wasp-service",
         "password123",
-        "secret"
+        "secret",
+        "inherit"
       ]
     }
   ],


### PR DESCRIPTION
## Proposed changes

### What changed

Created a new `post-merge.yml `GHA. 

### Why did it change

We previously deployed even if scan-repo failed post-merge. This now makes deploying depend on scan-repo completing successfully.

### Issue tracking

- [OJ-3746](https://govukverify.atlassian.net/browse/OJ-3746)

[OJ-3746]: https://govukverify.atlassian.net/browse/OJ-3746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ