### PR TITLE
OJ-3697: Upgrade jackson-databind to v2.22.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,12 @@ subprojects {
 		}
 	}
 
+	configurations.configureEach {
+		resolutionStrategy {
+			force 'com.fasterxml.jackson.core:jackson-databind:2.22.1'
+		}
+	}
+
 	dependencies {
 		implementation(platform(libs.aws.sdk.bom))
 		implementation(libs.aws.crt.client)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 aws-sdk = "2.41.25"
 aws-lambda-events = "3.14.0"
-jackson = "2.22.0"
+jackson = "2.22.1"
 jackson_annotations = "2.22" # annotations has no patch version
 nimbus-oauth = "11.29.1"
 nimbus-jwt = "10.5"
@@ -9,7 +9,7 @@ junit = "5.14.1"
 junit-launcher = "1.12.2"
 mockito = "5.20.0"
 powertools = "2.10.0"
-cri-common-lib = "9.1.0"
+cri-common-lib = "9.1.2"
 pact-provider = "4.6.20"
 webcompere = "2.1.6"
 otel = "1.62.0"


### PR DESCRIPTION
## Proposed changes

### What changed

- Upgraded jackson-databind and CRI Lib to latest versions

### Why did it change

- https://github.com/govuk-one-login/ipv-cri-kbv-api/security/dependabot/49
- https://github.com/govuk-one-login/ipv-cri-kbv-api/security/dependabot/48
- https://github.com/govuk-one-login/ipv-cri-kbv-api/security/dependabot/47
- https://github.com/govuk-one-login/ipv-cri-kbv-api/security/dependabot/54
- https://github.com/govuk-one-login/ipv-cri-kbv-api/security/dependabot/51
- https://github.com/govuk-one-login/ipv-cri-kbv-api/security/dependabot/52
- https://github.com/govuk-one-login/ipv-cri-kbv-api/security/dependabot/53
- https://github.com/govuk-one-login/ipv-cri-kbv-api/security/dependabot/50

### Issue tracking

- OJ-3697

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks