### PR TITLE
feat: make X-Forwarded-For header optional on session endpoint

### DIFF
--- a/infrastructure/lambda/private-api.yaml
+++ b/infrastructure/lambda/private-api.yaml
@@ -50,7 +50,7 @@ paths:
           schema:
             type: string
             format: uuid
-          required: true
+          required: false
         - $ref: '#/components/parameters/AuditHeader'
       requestBody:
         content:


### PR DESCRIPTION
## Proposed changes

### What changed

Updated the /session endpoint OpenAPI specification to make the X-Forwarded-For header optional instead of required.

### Why did it change
To align the KBV CRI session endpoint with the agreed approach used by Check HMRC, ensuring a consistent API contract across CRIs and removing the need for consumers and test tooling to provide the X-Forwarded-For header specifically for KBV.

### Issue tracking
- [OJ-3801](https://govukverify.atlassian.net/browse/OJ-3801)

[OJ-3801]: https://govukverify.atlassian.net/browse/OJ-3801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ