### PR TITLE
OJ-3823: Add OAuthCommon upto staging

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -18,10 +18,14 @@ jobs:
   build:
     name: Build SAM app
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      id-token: write
+      contents: read
     outputs:
       cache-key: ${{ steps.build.outputs.cache-key }}
       cache-restore-keys: ${{ steps.build.outputs.cache-restore-keys }}
+    environment:
+      name: development
     steps:
       - name: Pull repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
@@ -38,13 +42,14 @@ jobs:
           cache: gradle
 
       - name: Build SAM application
-        uses: govuk-one-login/github-actions/sam/build-application@87ae1213145261e3837cc38d5b9317422acd95c2
+        uses: govuk-one-login/github-actions/sam/build-application@4c76410195b5fcb1804fc7c183ed20704252830f
         id: build
         with:
           template: infrastructure/lambda/template.yaml
           pull-repository: false
           cache-name: kbv-api
           source-dir: lambdas
+          aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}
 
   deploy:
     name: Deploy stack
@@ -74,12 +79,12 @@ jobs:
         run: echo "timestamp=$(date +%s)" >> $GITHUB_OUTPUT
 
       - name: Deploy stack
-        uses: govuk-one-login/github-actions/sam/deploy-stack@d201191485b645ec856a34e5ca48636cf97b2574
+        uses: govuk-one-login/github-actions/sam/deploy-stack@4c76410195b5fcb1804fc7c183ed20704252830f
         id: deploy
         with:
           sam-deployment-bucket: ${{ vars.DEPLOYMENT_ARTIFACTS_BUCKET }}
           aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}
-          stack-name-prefix: preview-kbv-api
+          stack-name-prefix: preview
           cache-key: ${{ needs.build.outputs.cache-key }}
           cache-restore-keys: ${{ needs.build.outputs.cache-restore-keys }}
           s3-prefix: preview

--- a/deploy.sh
+++ b/deploy.sh
@@ -23,7 +23,7 @@ sam deploy --stack-name "$stack_name" \
   --resolve-s3 \
   --s3-prefix "$stack_name" \
   --region "${AWS_REGION:-eu-west-2}" \
-  --capabilities CAPABILITY_IAM \
+  --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND \
   --tags \
   cri:component=ipv-cri-kbv-api \
   cri:stack-type=localdev \

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -79,6 +79,11 @@ Conditions:
     - !Condition IsBuildEnvironment
   IsNotDevBuildLikeEnvironment: !Not
     - !Condition IsDevBuildLikeEnvironment
+  IsNotIntOrProdEnvironment: !Not 
+    - !Or
+      - !Condition IsProductionEnvironment
+      - !Equals [!Ref Environment, integration]
+
   CreateOAuthSSMParam: !And
     - !Not [!Condition IsLocalDevEnvironment]
     - !Not [!Condition IsProductionEnvironment]
@@ -243,18 +248,42 @@ Mappings:
       uat: https://identityiq.uat.xml.uk.experian.com/IdentityIQWebService/IdentityIQWebService.asmx
 
   EnvironmentConfiguration:
-    dev:
-      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     localdev:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+      BaseURL: https://review-k.dev.account.gov.uk
+      CoreRedirectURI: https://identity.staging.account.gov.uk/credential-issuer/callback?id=kbv
+      StubJwksEndpoint: https://test-resources.review-k.dev.account.gov.uk/.well-known/jwks.json
+      ProvisionedConcurrency: 0
+    dev:
+      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+      BaseURL: https://review-k.dev.account.gov.uk
+      CoreRedirectURI: https://identity.staging.account.gov.uk/credential-issuer/callback?id=kbv
+      StubJwksEndpoint: https://test-resources.review-k.dev.account.gov.uk/.well-known/jwks.json
+      ProvisionedConcurrency: 0
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+      BaseURL: https://review-k.build.account.gov.uk
+      CoreRedirectURI: https://identity.staging.account.gov.uk/credential-issuer/callback?id=kbv
+      StubJwksEndpoint: https://test-resources.review-k.build.account.gov.uk/.well-known/jwks.json
+      ProvisionedConcurrency: 1
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+      BaseURL: https://review-k.staging.account.gov.uk
+      CoreRedirectURI: https://identity.staging.account.gov.uk/credential-issuer/callback?id=kbv
+      StubJwksEndpoint: https://test-resources.review-k.staging.account.gov.uk/.well-known/jwks.json
+      ProvisionedConcurrency: 0
     integration:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+      BaseURL: https://review-k.integration.account.gov.uk
+      CoreRedirectURI: https://identity.integration.account.gov.uk/credential-issuer/callback?id=kbv
+      StubJwksEndpoint: https://test-resources.review-k.integration.account.gov.uk/.well-known/jwks.json
+      ProvisionedConcurrency: 0
     production:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
+      BaseURL: https://review-k.account.gov.uk
+      CoreRedirectURI: https://identity.account.gov.uk/credential-issuer/callback?id=kbv
+      StubJwksEndpoint: ""
+      ProvisionedConcurrency: 1
 
   MemorySizeMapping:
     Environment:
@@ -313,6 +342,47 @@ Mappings:
       localdev: HOURS
 
 Resources:
+  OAuth:
+    Type: AWS::Serverless::Application
+    Condition: IsNotIntOrProdEnvironment
+    Properties:
+      Location:
+        ApplicationId: arn:aws:serverlessrepo:eu-west-2:667736788427:applications/di-ipv-cri-oauth-common
+        SemanticVersion: 1.0.0
+      Parameters:
+        AuditEventNamePrefix: IPV_KBV_CRI
+        BuildNotificationStackName: slack-notifications
+        CommonLambdasStackName: !Ref CommonStackName
+        CommonLambdasUsesCMK: true
+        CSLSDestinationArn: !If
+          - IsNotDevBuildLikeEnvironment
+          - arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
+          - !Ref AWS::NoValue
+        CriIdentifier: !Ref CriIdentifier
+        CriAudience: !FindInMap [EnvironmentConfiguration, !Ref Environment, BaseURL]
+        CriVcIssuer: !FindInMap [EnvironmentConfiguration, !Ref Environment, BaseURL]
+        CriPrivateApiGwName: !Sub kbv-cri-private-${AWS::StackName}
+        CriPublicApiGwName: !Sub kbv-cri-${AWS::StackName}
+        CriPrivateApiGatewayID: !Sub ${PrivateKBVApi}
+        CriPublicApiGatewayID: !Sub ${PublicKBVApi}
+        Environment: !If
+          - IsLocalDevEnvironment
+          - dev
+          - !Ref Environment
+        IPVCoreRedirectURI: !FindInMap [EnvironmentConfiguration, !Ref Environment, CoreRedirectURI]
+        IPVCoreStubJwksEndpoint: !FindInMap [EnvironmentConfiguration, !Ref Environment, StubJwksEndpoint]
+        LambdaCodeSigningConfigArn: !If
+          - UseCodeSigningConfigArn
+          - !Ref CodeSigningConfigArn
+          - !Ref AWS::NoValue
+        LambdaDeploymentPreference: !Ref LambdaDeploymentPreference
+        LambdaProvisionedConcurrentExecutions: !FindInMap [EnvironmentConfiguration, !Ref Environment, ProvisionedConcurrency]
+        LambdaVpcConfiguration: di-ipv-cri-pipeline-deployment
+        PermissionsBoundaryArn: !If
+          - UsePermissionsBoundary
+          - !Ref PermissionsBoundary
+          - !Ref AWS::NoValue
+
   HealthCheckFunction:
     Type: AWS::Serverless::Function
     Properties:


### PR DESCRIPTION
## Proposed changes

### What changed

- Add OAuthCommon stack up to staging.
- Bump build & deploy preview stack actions to now support SAR.

### Why did it change

The first step of the migration will require us to have the OAuth Common stack deployed and ready for the CRI to use as part of subsequent steps.

### Issue tracking

- [OJ-3823](https://govukverify.atlassian.net/browse/OJ-3823)

[OJ-3823]: https://govukverify.atlassian.net/browse/OJ-3823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ