### PR TITLE
OJ-3847: Bump apache cxf to v4.2.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ pact-provider = "4.6.20"
 webcompere = "2.1.6"
 otel = "1.62.0"
 otel-alpha = "2.12.0-alpha"
-apache-cfx = "4.1.4"
+apache-cxf = "4.2.3"
 jakata-xml = "4.0.2"
 log4j = "2.25.4"
 
@@ -55,8 +55,8 @@ jakarta-annotation = { module = "jakarta.annotation:jakarta.annotation-api", ver
 
 # SOAP / CXF
 saaj = { module = "com.sun.xml.messaging.saaj:saaj-impl", version = "3.0.4" }
-cxf-jaxws = { module = "org.apache.cxf:cxf-rt-frontend-jaxws", version.ref = "apache-cfx" }
-cxf-http = { module = "org.apache.cxf:cxf-rt-transports-http", version.ref = "apache-cfx" }
+cxf-jaxws = { module = "org.apache.cxf:cxf-rt-frontend-jaxws", version.ref = "apache-cxf" }
+cxf-http = { module = "org.apache.cxf:cxf-rt-transports-http", version.ref = "apache-cxf" }
 httpasyncclient = { module = "org.apache.httpcomponents:httpasyncclient", version = "4.1.5" }
 
 # Powertools


### PR DESCRIPTION
## Proposed changes

### What changed

- Bumped apache-cxf packages to v4.2.3

### Why did it change

- https://github.com/govuk-one-login/ipv-cri-kbv-api/security/dependabot/55

### Issue tracking

- OJ-3847

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks