### PR TITLE
OJ-3847: Bump CXF version in wsdl2java configuration

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -49,7 +49,7 @@ sourceSets {
 
 wsdl2java {
 	useJakarta = true
-	cxfVersion = "4.1.3"
+	cxfVersion = "4.2.3"
 	includes = [
 		'wsdl/iiq-wasp-token.wsdl',
 		'wsdl/iiq-service.wsdl'


### PR DESCRIPTION
## Proposed changes

### What changed

- Bump CXF version as referenced in `wsdl2java` block in `build.gradle`

### Why did it change

- We have bumped the Apache CXF dependencies; we should tell `wsdl2java` this
- https://github.com/govuk-one-login/ipv-cri-kbv-api/security/dependabot/55 has not gone away

### Issue tracking

- OJ-3847

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks