### PR TITLE
OJ-3826: Set OAuthCommonLambdas to true in dev 

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -263,7 +263,7 @@ Mappings:
       CoreRedirectURI: https://identity.staging.account.gov.uk/credential-issuer/callback?id=kbv
       StubJwksEndpoint: https://test-resources.review-k.dev.account.gov.uk/.well-known/jwks.json
       ProvisionedConcurrency: 0
-      OAuthCommonLambdas: false
+      OAuthCommonLambdas: true
       OAuthCommonTables: false
     dev:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -271,7 +271,7 @@ Mappings:
       CoreRedirectURI: https://identity.staging.account.gov.uk/credential-issuer/callback?id=kbv
       StubJwksEndpoint: https://test-resources.review-k.dev.account.gov.uk/.well-known/jwks.json
       ProvisionedConcurrency: 0
-      OAuthCommonLambdas: false
+      OAuthCommonLambdas: true
       OAuthCommonTables: false
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables

--- a/integration-tests/src/test/java/gov/uk/kbv/api/stepdefinitions/KbvSteps.java
+++ b/integration-tests/src/test/java/gov/uk/kbv/api/stepdefinitions/KbvSteps.java
@@ -7,10 +7,13 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jwt.SignedJWT;
 import gov.uk.kbv.api.client.KbvApiClient;
+import gov.uk.kbv.api.util.DynamoDbHelper;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import uk.gov.di.ipv.cri.common.library.aws.CloudFormationHelper;
 import uk.gov.di.ipv.cri.common.library.client.ClientConfigurationService;
+import uk.gov.di.ipv.cri.common.library.config.Environment;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEvent;
 import uk.gov.di.ipv.cri.common.library.domain.TestHarnessResponse;
 import uk.gov.di.ipv.cri.common.library.stepdefinitions.CriTestContext;
@@ -304,5 +307,38 @@ public class KbvSteps {
 
         assertTrue(response.get("error").asText().contains("SAA response timed out"));
         assertEquals(504, this.testContext.getResponse().statusCode());
+    }
+
+    @Then("the sessions exist in the CommonLambdas tables is {word}")
+    public void theSessionsExistInTheCommonLambdasTables(String isExpected) {
+        String commonStackName = Environment.getEnvOrDefault("COMMON_STACK_NAME", "common-cri-api");
+        String sessionTableName = "session-" + commonStackName;
+        String personIdentityTableName = "person-identity-" + commonStackName;
+
+        assertEquals(
+                Boolean.parseBoolean(isExpected),
+                DynamoDbHelper.sessionExists(sessionTableName, this.testContext.getSessionId()));
+        assertEquals(
+                Boolean.parseBoolean(isExpected),
+                DynamoDbHelper.sessionExists(
+                        personIdentityTableName, this.testContext.getSessionId()));
+    }
+
+    @Then("the sessions exist in the OAuthCommon tables is {word}")
+    public void theSessionsExistInTheOAuthCommonTables(String isExpected) {
+        String stackName = Environment.getEnv("STACK_NAME");
+        String oAuthStackName = CloudFormationHelper.getOutput(stackName, "OAuthCommonStackName");
+        String sessionTableName =
+                CloudFormationHelper.getOutput(oAuthStackName, "DbSessionTableName");
+        String personIdentityTableName =
+                CloudFormationHelper.getOutput(oAuthStackName, "DbPersonIdentityTableName");
+
+        assertEquals(
+                Boolean.parseBoolean(isExpected),
+                DynamoDbHelper.sessionExists(sessionTableName, this.testContext.getSessionId()));
+        assertEquals(
+                Boolean.parseBoolean(isExpected),
+                DynamoDbHelper.sessionExists(
+                        personIdentityTableName, this.testContext.getSessionId()));
     }
 }

--- a/integration-tests/src/test/java/gov/uk/kbv/api/util/DynamoDbHelper.java
+++ b/integration-tests/src/test/java/gov/uk/kbv/api/util/DynamoDbHelper.java
@@ -1,0 +1,28 @@
+package gov.uk.kbv.api.util;
+
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
+import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
+
+import java.util.Map;
+
+public class DynamoDbHelper {
+
+    private static final DynamoDbClient DYNAMO_DB_CLIENT = DynamoDbClient.builder().build();
+
+    public static boolean sessionExists(String tableName, String sessionId) {
+        QueryRequest request =
+                QueryRequest.builder()
+                        .tableName(tableName)
+                        .keyConditionExpression("sessionId = :sessionId")
+                        .expressionAttributeValues(
+                                Map.of(":sessionId", AttributeValue.builder().s(sessionId).build()))
+                        .limit(1)
+                        .build();
+
+        QueryResponse response = DYNAMO_DB_CLIENT.query(request);
+
+        return response.count() > 0;
+    }
+}

--- a/integration-tests/src/test/resources/features/KbvApiHappyPath.feature
+++ b/integration-tests/src/test/resources/features/KbvApiHappyPath.feature
@@ -111,6 +111,10 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 3 question
     And a verification score of 2 is returned in the response
     And the check details array has 3 objects returned in the response
 
+    # Migration table check
+    Then the sessions exist in the CommonLambdas tables is true
+    And the sessions exist in the OAuthCommon tables is false
+
     Examples:
       | user |
       | 197  |


### PR DESCRIPTION
## Proposed changes

### What changed

- Enabled `OAuthCommonLambdas` in dev (& localdev)
- Added validation on which tables were written to in the integrations tests. 

Note: DynamoDbHelper could go in `cri-lib` to be shared, but changes to `cri-lib` is blocked on https://govukverify.atlassian.net/browse/OJ-3857

### Why did it change

To use OAuthCommon Lambdas in dev, but with the CommonLambdas tables. 

### Issue tracking

- [OJ-3826](https://govukverify.atlassian.net/browse/OJ-3826)

[OJ-3826]: https://govukverify.atlassian.net/browse/OJ-3826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ